### PR TITLE
gdf/docs and guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ DEVNET = chain_endpoint $(DEVNET_ENDPOINT)
 
 TESTNET = network test
 
-# NETUID = 1
-NETUID = 165
+NETUID = 1
+# NETUID = 165
 
 
 ########################################################################
 #####                       SELECT YOUR ENV                        #####
 ########################################################################
 # SUBTENSOR_ENVIRONMENT = $(LOCALNET)
-# SUBTENSOR_ENVIRONMENT = $(DEVNET)
-SUBTENSOR_ENVIRONMENT = $(TESTNET)
+SUBTENSOR_ENVIRONMENT = $(DEVNET)
+# SUBTENSOR_ENVIRONMENT = $(TESTNET)
 
 
 ########################################################################

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ DEVNET = chain_endpoint $(DEVNET_ENDPOINT)
 
 TESTNET = network test
 
-NETUID = 1
-# NETUID = 165
+NETUID = 1 # devnet
+# NETUID = 165 # testnet
 
 
 ########################################################################

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,16 @@ DEVNET = chain_endpoint $(DEVNET_ENDPOINT)
 
 TESTNET = network test
 
-NETUID = 1
+# NETUID = 1
+NETUID = 165
 
 
 ########################################################################
 #####                       SELECT YOUR ENV                        #####
 ########################################################################
 # SUBTENSOR_ENVIRONMENT = $(LOCALNET)
-SUBTENSOR_ENVIRONMENT = $(DEVNET)
-# SUBTENSOR_ENVIRONMENT = $(TESTNET)
+# SUBTENSOR_ENVIRONMENT = $(DEVNET)
+SUBTENSOR_ENVIRONMENT = $(TESTNET)
 
 
 ########################################################################
@@ -78,7 +79,7 @@ run-miner:
 	watchfiles "python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --logging.debug --axon.port 8091" .
 
 run-validator:
-	watchfiles "python neurons/validator.py --netuid 1 --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --logging.debug --axon.port 8092" .
+	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --logging.debug --axon.port 8092" .
 
 ## Docker commands
 docker-build:

--- a/docs/setup/2-install-packages.md
+++ b/docs/setup/2-install-packages.md
@@ -18,3 +18,5 @@ Set the `PYTHONPATH` environment variable to the root of the repository:
 ```cmd
 export PYTHONPATH=$PYTHONPATH:$(pwd)
 ```
+
+**Note:** Remember to set the `PYTHONPATH` environment variable for each terminal session.

--- a/docs/setup/8-run-protocol.md
+++ b/docs/setup/8-run-protocol.md
@@ -80,16 +80,21 @@ This directory is mapped from `/home/masa/.masa/` inside the Docker container, e
 
 ## Funding the Node (in order to Stake)
 
-Find the public key of your node in the logs:
-the logs:
+The node will need to be funded with `1000` tMASA tokens and `0.01` sepoliaETH. For tMASA tokens, you can use our faucet:
+
+```bash
+docker-compose run --rm masa-node /usr/bin/masa-node --faucet
+```
+
+If the faucet is empty, you can manually request tokens using our form. First, find the public key of your node in the logs:
 
 ```bash
 docker-compose logs -f masa-node
 ```
 
-Head to **[our form](xhttps://docs.google.com/forms/d/e/1FAIpQLSc344bmJfWYcjAEyDdfKTorDsylEyNU-YppmhQNV89f90RK0w/viewform)** to request test Masa tokens on Sepolia. Send 1000 MASA and .01 sepoliaETH to the node's public key / wallet address.
+Then, head to **[our form](xhttps://docs.google.com/forms/d/e/1FAIpQLSc344bmJfWYcjAEyDdfKTorDsylEyNU-YppmhQNV89f90RK0w/viewform)** to request test Masa tokens on Sepolia with your nodes address.
 
-When the transactions have settled, you can stake:
+For sepoliaETH, you can use a faucet **[like this one](https://www.alchemy.com/faucets/ethereum-sepolia).** When both transactions have settled, you can stake:
 
 ## Staking the Node
 

--- a/docs/setup/8-run-protocol.md
+++ b/docs/setup/8-run-protocol.md
@@ -92,7 +92,7 @@ If the faucet is empty, you can manually request tokens using our form. First, f
 docker-compose logs -f masa-node
 ```
 
-Then, head to **[our form](xhttps://docs.google.com/forms/d/e/1FAIpQLSc344bmJfWYcjAEyDdfKTorDsylEyNU-YppmhQNV89f90RK0w/viewform)** to request test Masa tokens on Sepolia with your nodes address.
+Then, head to **[our form](https://docs.google.com/forms/d/e/1FAIpQLSc344bmJfWYcjAEyDdfKTorDsylEyNU-YppmhQNV89f90RK0w/viewform)** to request test Masa tokens on Sepolia with your nodes address.
 
 For sepoliaETH, you can use a faucet **[like this one](https://www.alchemy.com/faucets/ethereum-sepolia).** When both transactions have settled, you can stake:
 

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -17,7 +17,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-
+import os
 import copy
 import torch
 import asyncio
@@ -364,7 +364,11 @@ class BaseValidatorNeuron(BaseNeuron):
         
 
         # Load the state of the validator from file.
-        state = torch.load(self.config.neuron.full_path + "/state.pt")
-        self.step = state["step"]
-        self.scores = state["scores"]
-        self.hotkeys = state["hotkeys"]
+        state_path = self.config.neuron.full_path + "/state.pt"
+        if os.path.isfile(state_path):
+            state = torch.load(state_path)
+            self.step = state["step"]
+            self.scores = state["scores"]
+            self.hotkeys = state["hotkeys"]
+        else:
+            bt.logging.warning(f"State file not found at {state_path}. Skipping state load.")


### PR DESCRIPTION
- fixes hardcoded netuid in makefile
- adds footnote to docs for setting pythonpath on new terminal
- adds guard to there not being a validator state file (occurs on first run)
- adds information about using the masa protocol faucet for node staking
