### PR TITLE
feat: implements basic miner blacklist using vpermit and min stake req

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ DEVNET = chain_endpoint $(DEVNET_ENDPOINT)
 
 TESTNET = network test
 
-NETUID = 1 # devnet
-# NETUID = 165 # testnet
+# NETUID = 1 # devnet
+NETUID = 165 # testnet
 
 
 ########################################################################
 #####                       SELECT YOUR ENV                        #####
 ########################################################################
 # SUBTENSOR_ENVIRONMENT = $(LOCALNET)
-SUBTENSOR_ENVIRONMENT = $(DEVNET)
-# SUBTENSOR_ENVIRONMENT = $(TESTNET)
+# SUBTENSOR_ENVIRONMENT = $(DEVNET)
+SUBTENSOR_ENVIRONMENT = $(TESTNET)
 
 
 ########################################################################
@@ -76,10 +76,10 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug" .
+	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
 
 run-validator:
-	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug" .
+	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
 
 ## Docker commands
 docker-build:
@@ -120,4 +120,4 @@ run-localnet:
 
 ## Hyperparameters
 hyperparameters:
-	btcli subnets hyperparameters --subtensor.$(SUBTENSOR_ENVIRONMENT)
+	btcli subnets hyperparameters --subtensor.$(SUBTENSOR_ENVIRONMENT) --netuid $(NETUID)

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ DEVNET = chain_endpoint $(DEVNET_ENDPOINT)
 
 TESTNET = network test
 
-# NETUID = 1 # devnet
-NETUID = 165 # testnet
+NETUID = 1 # devnet
+# NETUID = 165 # testnet
 
 
 ########################################################################
 #####                       SELECT YOUR ENV                        #####
 ########################################################################
 # SUBTENSOR_ENVIRONMENT = $(LOCALNET)
-# SUBTENSOR_ENVIRONMENT = $(DEVNET)
-SUBTENSOR_ENVIRONMENT = $(TESTNET)
+SUBTENSOR_ENVIRONMENT = $(DEVNET)
+# SUBTENSOR_ENVIRONMENT = $(TESTNET)
 
 
 ########################################################################

--- a/Makefile
+++ b/Makefile
@@ -117,3 +117,7 @@ build-binary:
 
 run-localnet:
 	BUILD_BINARY=0 ./scripts/localnet.sh
+
+## Hyperparameters
+hyperparameters:
+	btcli subnets hyperparameters --subtensor.$(SUBTENSOR_ENVIRONMENT)

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	watchfiles "python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --logging.debug --axon.port 8091" .
+	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --logging.debug --axon.port 8091" .
 
 run-validator:
 	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --logging.debug --axon.port 8092" .

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --logging.debug --axon.port 8091" .
+	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug" .
 
 run-validator:
-	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --logging.debug --axon.port 8092" .
+	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug" .
 
 ## Docker commands
 docker-build:

--- a/docs/advanced/blacklisting.md
+++ b/docs/advanced/blacklisting.md
@@ -2,13 +2,13 @@
 
 ## VPermit Filter
 
-Current blacklisting logic is implemented by passing a flag to the miner:
+To remove the miner accepting any request warning, pass the following flag to toggle on checking for a `vpermit` in the blacklisting function:
 
 ```bash
 python neurons/miner.py --blacklist.force_validator_permit
 ```
 
-The blacklisting function extends that of the subnet-template:
+Additionally, our blacklisting function extends that of the subnet-template and checks for a certain amount of stake, updated every tempo:
 
 ```python
 async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:

--- a/docs/advanced/blacklisting.md
+++ b/docs/advanced/blacklisting.md
@@ -1,0 +1,34 @@
+# Blacklisting
+
+## VPermit Filter
+
+Current blacklisting logic is implemented by passing a flag to the miner:
+
+```bash
+python neurons/miner.py --blacklist.force_validator_permit
+```
+
+The above toggles the blacklisting logic, which is currently configured to filter out requests from neuron uid's that do _not_ have a valid permit.
+
+```python
+[blacklisted, reason] = await self.blacklist(synapse)
+if blacklisted:
+    bt.logging.warning(f"Blacklisting un-registered hotkey for reason: {reason}")
+    return synapse
+```
+
+The blacklisting function mimics that of the subnet-template:
+
+```python
+async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:
+    uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+    bt.logging.info(f"Validator Permit: {self.metagraph.validator_permit[uid]}")
+    if not self.config.blacklist.allow_non_registered and synapse.dendrite.hotkey not in self.metagraph.hotkeys:
+        bt.logging.warning(f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}")
+        return True, "Unrecognized hotkey"
+    if self.config.blacklist.force_validator_permit and not self.metagraph.validator_permit[uid]:
+        bt.logging.warning(f"Blacklisting a request from non-validator hotkey {synapse.dendrite.hotkey}")
+        return True, "Non-validator hotkey"
+    bt.logging.info(f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}")
+    return False, "Hotkey recognized!"
+```

--- a/docs/advanced/blacklisting.md
+++ b/docs/advanced/blacklisting.md
@@ -15,7 +15,7 @@ Additionally, our blacklisting function extends that of the subnet-template and 
 ```python
 async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:
 
-    if await self.check_tempo(synapse):
+    if self.check_tempo(synapse):
         await self.check_stake(synapse)
 
     hotkey = synapse.dendrite.hotkey

--- a/docs/advanced/blacklisting.md
+++ b/docs/advanced/blacklisting.md
@@ -17,18 +17,32 @@ if blacklisted:
     return synapse
 ```
 
-The blacklisting function mimics that of the subnet-template:
+The blacklisting function extends that of the subnet-template:
 
 ```python
 async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:
-    uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+
+    if await self.check_tempo():
+        await self.check_stake(synapse)
+
+    hotkey = synapse.dendrite.hotkey
+    uid = self.metagraph.hotkeys.index(hotkey)
+
+    bt.logging.info(f"Neurons Staked: {self.neurons_permit_stake}")
     bt.logging.info(f"Validator Permit: {self.metagraph.validator_permit[uid]}")
-    if not self.config.blacklist.allow_non_registered and synapse.dendrite.hotkey not in self.metagraph.hotkeys:
-        bt.logging.warning(f"Blacklisting un-registered hotkey {synapse.dendrite.hotkey}")
+
+    if not self.config.blacklist.allow_non_registered and hotkey not in self.metagraph.hotkeys:
+        bt.logging.warning(f"Blacklisting un-registered hotkey {hotkey}")
         return True, "Unrecognized hotkey"
     if self.config.blacklist.force_validator_permit and not self.metagraph.validator_permit[uid]:
-        bt.logging.warning(f"Blacklisting a request from non-validator hotkey {synapse.dendrite.hotkey}")
+        bt.logging.warning(f"Blacklisting a request from non-validator hotkey {hotkey}")
         return True, "Non-validator hotkey"
-    bt.logging.info(f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}")
+    if hotkey not in self.neurons_permit_stake:
+        bt.logging.warning(f"Blacklisting a request from neuron without enough staked: {hotkey}")
+        return True, "Non-staked neuron"
+
+    bt.logging.info(f"Not Blacklisting recognized hotkey {hotkey}")
     return False, "Hotkey recognized!"
 ```
+
+A check for a certain amount of stake is added to the blacklisting function, updating every tempo. This creates the requirement that a neuron must have staked for at least the tempo amount of blocks to be considered valid. This prevents spam and ensures that the network is not overwhelmed by new neurons. Now, with the presence of both a `vpermit` and having your `hotkey` listed on the permit_stake whitelist, you are considered a validator.

--- a/docs/advanced/blacklisting.md
+++ b/docs/advanced/blacklisting.md
@@ -8,6 +8,8 @@ To remove the miner accepting any request warning, pass the following flag to to
 python neurons/miner.py --blacklist.force_validator_permit
 ```
 
+## Stake Filter
+
 Additionally, our blacklisting function extends that of the subnet-template and checks for a certain amount of stake, updated every tempo:
 
 ```python

--- a/docs/advanced/blacklisting.md
+++ b/docs/advanced/blacklisting.md
@@ -15,7 +15,7 @@ Additionally, our blacklisting function extends that of the subnet-template and 
 ```python
 async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:
 
-    if await self.check_tempo():
+    if await self.check_tempo(synapse):
         await self.check_stake(synapse)
 
     hotkey = synapse.dendrite.hotkey
@@ -30,7 +30,7 @@ async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:
     if self.config.blacklist.force_validator_permit and not self.metagraph.validator_permit[uid]:
         bt.logging.warning(f"Blacklisting a request from non-validator hotkey {hotkey}")
         return True, "Non-validator hotkey"
-    if hotkey not in self.neurons_permit_stake:
+    if hotkey not in self.neurons_permit_stake.keys():
         bt.logging.warning(f"Blacklisting a request from neuron without enough staked: {hotkey}")
         return True, "Non-staked neuron"
 

--- a/docs/advanced/blacklisting.md
+++ b/docs/advanced/blacklisting.md
@@ -8,15 +8,6 @@ Current blacklisting logic is implemented by passing a flag to the miner:
 python neurons/miner.py --blacklist.force_validator_permit
 ```
 
-The above toggles the blacklisting logic, which is currently configured to filter out requests from neuron uid's that do _not_ have a valid permit.
-
-```python
-[blacklisted, reason] = await self.blacklist(synapse)
-if blacklisted:
-    bt.logging.warning(f"Blacklisting un-registered hotkey for reason: {reason}")
-    return synapse
-```
-
 The blacklisting function extends that of the subnet-template:
 
 ```python

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -75,7 +75,8 @@ class BaseMinerNeuron(BaseNeuron):
 
         self.neurons_permit_stake: List[str] = [] # list of neurons (hotkeys) that meet min stake requirement
         self.min_stake_required: int = 10 # note, this will be variable per environment
-        self.tempo: int = self.subtensor.get_subnet_hyperparameters(self.config.netuid).tempo
+        # self.tempo: int = self.subtensor.get_subnet_hyperparameters(self.config.netuid).tempo #note, this breaks on devnet due to hyperparam issue
+        self.tempo: int = 360 # note, remove once hyperparam calls are fixed in devnet
         self.last_checked_block = None
 
         self.load_state()

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -74,7 +74,7 @@ class BaseMinerNeuron(BaseNeuron):
         self.lock = asyncio.Lock()
 
         self.neurons_permit_stake: Dict[str, int] = {} # dict of neurons (hotkeys) that meet min stake requirement with their respective last fetched block numbers
-        self.min_stake_required: int = 10 # note, this will be variable per environment
+        self.min_stake_required: int = self.config.blacklist.min_stake_required # note, this will be variable per environment
         # self.tempo: int = self.subtensor.get_subnet_hyperparameters(self.config.netuid).tempo #note, this breaks on devnet due to hyperparam issue
         self.tempo: int = 10 # note, remove once hyperparam calls are fixed in devnet
 

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -224,7 +224,7 @@ class BaseMinerNeuron(BaseNeuron):
         state_path = self.config.neuron.full_path + "/state.pt"
         if os.path.isfile(state_path):
             state = torch.load(state_path)
-            self.neurons_permit_stake = state["neurons_permit_stake"]
-            self.last_checked_block = state["last_checked_block"]
+            self.neurons_permit_stake = state.get("neurons_permit_stake", [])
+            self.last_checked_block = state.get("last_checked_block", None)
         else:
             bt.logging.warning(f"State file not found at {state_path}. Skipping state load.")

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -77,7 +77,7 @@ class BaseMinerNeuron(BaseNeuron):
         self.min_stake_required: int = 10 # note, this will be variable per environment
         # self.tempo: int = self.subtensor.get_subnet_hyperparameters(self.config.netuid).tempo #note, this breaks on devnet due to hyperparam issue
         self.tempo: int = 360 # note, remove once hyperparam calls are fixed in devnet
-        self.last_checked_block = None
+        self.last_checked_block: Union[int, None] = None
 
         self.load_state()
 

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -76,7 +76,7 @@ class BaseMinerNeuron(BaseNeuron):
         self.neurons_permit_stake: Dict[str, int] = {} # dict of neurons (hotkeys) that meet min stake requirement with their respective last fetched block numbers
         self.min_stake_required: int = 10 # note, this will be variable per environment
         # self.tempo: int = self.subtensor.get_subnet_hyperparameters(self.config.netuid).tempo #note, this breaks on devnet due to hyperparam issue
-        self.tempo: int = 360 # note, remove once hyperparam calls are fixed in devnet
+        self.tempo: int = 10 # note, remove once hyperparam calls are fixed in devnet
 
         self.load_state()
 

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -210,6 +210,7 @@ class BaseMinerNeuron(BaseNeuron):
         torch.save(
             {
                 "neurons_permit_stake": self.neurons_permit_stake,
+                "last_checked_block": self.last_checked_block,
             },
             self.config.neuron.full_path + "/state.pt",
         )
@@ -224,5 +225,6 @@ class BaseMinerNeuron(BaseNeuron):
         if os.path.isfile(state_path):
             state = torch.load(state_path)
             self.neurons_permit_stake = state["neurons_permit_stake"]
+            self.last_checked_block = state["last_checked_block"]
         else:
             bt.logging.warning(f"State file not found at {state_path}. Skipping state load.")

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -137,8 +137,6 @@ class BaseNeuron(ABC):
             except:
                 print("Setting weights failed")
 
-        # Always save state.
-
     def check_registered(self):
         # --- Check for registration.
         if not self.subtensor.is_hotkey_registered(
@@ -174,13 +172,3 @@ class BaseNeuron(ABC):
             > self.config.neuron.epoch_length
             and self.neuron_type != "MinerNeuron"
         )  # don't set weights if you're a miner
-
-    def save_state(self):
-        bt.logging.warning(
-            "save_state() not implemented for this neuron. You can implement this function to save model checkpoints or other useful data."
-        )
-
-    def load_state(self):
-        bt.logging.warning(
-            "load_state() not implemented for this neuron. You can implement this function to load model checkpoints or other useful data."
-        )

--- a/masa/utils/config.py
+++ b/masa/utils/config.py
@@ -158,6 +158,13 @@ def add_miner_args(cls, parser):
         help="Wandb entity to log to.",
     )
 
+    parser.add_argument(
+        "--neuron.debug",
+        action="store_true",
+        help="Sets debug to true",
+        default=False,
+    )
+
 
 def add_validator_args(cls, parser):
     """Add validator specific arguments to the parser."""

--- a/masa/utils/config.py
+++ b/masa/utils/config.py
@@ -136,6 +136,13 @@ def add_miner_args(cls, parser):
         help="If set, we will force incoming requests to have a permit.",
         default=False,
     )
+    
+    parser.add_argument(
+        "--blacklist.min_stake_required",
+        type=int,
+        help="Staked TAO required for validators to be considered valid.",
+        default=10,
+    )
 
     parser.add_argument(
         "--blacklist.allow_non_registered",

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -34,6 +34,8 @@ delay = 0
 class Miner(BaseMinerNeuron):
     def __init__(self, config=None):
         super(Miner, self).__init__(config=config)
+        bt.logging.info("Miner initialized with config: {}".format(config))
+
 
     async def forward(
         self, synapse: Request

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -89,7 +89,7 @@ class Miner(BaseMinerNeuron):
 
     async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:
 
-        if await self.check_tempo(synapse):
+        if self.check_tempo(synapse):
             await self.check_stake(synapse)
 
         hotkey = synapse.dendrite.hotkey

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -41,9 +41,9 @@ class Miner(BaseMinerNeuron):
         print(f"Sleeping for rate limiting purposes: {delay}s")
         time.sleep(delay)
 
-        is_blacklisted = await self.blacklist(synapse)
-        if is_blacklisted[0]:
-            bt.logging.warning(f"Blacklisting un-registered hotkey for reason: {is_blacklisted[1]}")
+        [blacklisted, reason] = await self.blacklist(synapse)
+        if blacklisted:
+            bt.logging.warning(f"Blacklisting un-registered hotkey for reason: {reason}")
             return synapse
         
         try:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -140,7 +140,7 @@ class Miner(BaseMinerNeuron):
         
         blocks_since_last_check = current_block - self.last_checked_block
         if blocks_since_last_check >= self.tempo:
-            bt.logging.info(f"A tempo has passed or there is no block set.  Blocks since last check: {blocks_since_last_check}")
+            bt.logging.info(f"A tempo has passed.  Blocks since last check: {blocks_since_last_check}")
             self.last_checked_block = current_block
             return True
         else:

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -89,7 +89,7 @@ class Miner(BaseMinerNeuron):
 
     async def blacklist(self, synapse: Request) -> typing.Tuple[bool, str]:
 
-        if await self.check_tempo():
+        if await self.check_tempo(synapse):
             await self.check_stake(synapse)
 
         hotkey = synapse.dendrite.hotkey
@@ -104,7 +104,7 @@ class Miner(BaseMinerNeuron):
         if self.config.blacklist.force_validator_permit and not self.metagraph.validator_permit[uid]:
             bt.logging.warning(f"Blacklisting a request from non-validator hotkey {hotkey}")
             return True, "Non-validator hotkey"
-        if hotkey not in self.neurons_permit_stake:
+        if hotkey not in self.neurons_permit_stake.keys():
             bt.logging.warning(f"Blacklisting a request from neuron without enough staked: {hotkey}")
             return True, "Non-staked neuron"
         
@@ -121,27 +121,31 @@ class Miner(BaseMinerNeuron):
         current_stakes = self.metagraph.S
         hotkey = synapse.dendrite.hotkey
         uid = self.metagraph.hotkeys.index(hotkey)
+        current_block = self.subtensor.get_current_block()
+        
         if current_stakes[uid] < self.min_stake_required:
-            if hotkey in self.neurons_permit_stake:
-                self.neurons_permit_stake.remove(hotkey)
+            if hotkey in self.neurons_permit_stake.keys():
+                del self.neurons_permit_stake[hotkey]
                 bt.logging.info(f"Removed neuron {hotkey} from staked list due to insufficient stake.")
         else:
-            if hotkey not in self.neurons_permit_stake:
-                self.neurons_permit_stake.append(hotkey)
+            if hotkey not in self.neurons_permit_stake.keys():
+                self.neurons_permit_stake[hotkey] = current_block
                 bt.logging.info(f"Added neuron {hotkey} to staked list.")
 
     
-    async def check_tempo(self) -> bool:
+    async def check_tempo(self, synapse: Request) -> bool:
+        hotkey = synapse.dendrite.hotkey
         current_block = self.subtensor.get_current_block()
-        if self.last_checked_block is None:
+        last_checked_block = self.neurons_permit_stake.get(hotkey)
+        if last_checked_block is None:
             bt.logging.info(f"There is no block set.  Setting last checked block to {current_block}")
-            self.last_checked_block = current_block
+            self.neurons_permit_stake[hotkey] = current_block
             return True
         
-        blocks_since_last_check = current_block - self.last_checked_block
+        blocks_since_last_check = current_block - last_checked_block
         if blocks_since_last_check >= self.tempo:
             bt.logging.info(f"A tempo has passed.  Blocks since last check: {blocks_since_last_check}")
-            self.last_checked_block = current_block
+            self.neurons_permit_stake[hotkey] = current_block
             return True
         else:
             bt.logging.info(f"Not yet a tempo since last check. Blocks since last check: {blocks_since_last_check}")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -24,9 +24,6 @@ from masa.api.request import RequestType
 
 # Bittensor Validator Template:
 from masa.base.validator import BaseValidatorNeuron
-from masa.validator.twitter.profile.forward import ProfileForwarder
-from masa.validator.twitter.followers.forward import FollowersForwarder
-from masa.validator.twitter.tweets.forward import TweetsForwarder
 from masa.api.validator_api import ValidatorAPI
 
 class Validator(BaseValidatorNeuron):


### PR DESCRIPTION
## Description
- using #64 and #88 implements basic blacklist functionality as described in #89

## Features
- adds logs to display blacklisting reasons, vpermit status, and stake size
- saves and loads state related to storing neurons with min stake required (by hotkey)
- checks stake size per hotkey every 1 tempo to ensure we aren't checking stakes on every request
- resolves console warning in miner about allowing any requests through
- updates docs in `docs/advanced/blacklisting`

## Example
- validator with enough stake:
![image](https://github.com/masa-finance/masa-bittensor/assets/18288572/ebbcf70d-ffe4-465e-8728-09e92a4b5ad4)

- validator blacklisted:
![image](https://github.com/masa-finance/masa-bittensor/assets/18288572/8a8f90bf-6585-45f6-a4e4-824efde19897)

TODO
- [x] investigate why miner's _also_ have a vpermit, as seen with `make overview-all`
![Screenshot 2024-06-12 at 11 34 41 AM](https://github.com/masa-finance/masa-bittensor/assets/18288572/8d8ea632-4e86-4d2c-9375-4d3df1dbf4e5)
(answer is in #88)
