### PR TITLE
feat: implement basic sanitation for miner selection

### DIFF
--- a/masa/utils/uids.py
+++ b/masa/utils/uids.py
@@ -118,7 +118,7 @@ async def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.Long
         If `k` is larger than the number of available `uids`, set `k` to the number of
         available `uids`.
     """
-    dendrite = bt.dendrite(wallet=bt.wallet)
+    dendrite = bt.dendrite(wallet=self.wallet)
 
     print("get random uids")
 

--- a/masa/utils/uids.py
+++ b/masa/utils/uids.py
@@ -140,7 +140,7 @@ async def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.Long
         uids = torch.tensor(random_sample)
         return uids
     except Exception as e:
-        bt.logging.error(message=f"Failed to get random miner uids: {e}")
+        bt.logging.error(f"Failed to get random miner uids: {e}")
         return None
     finally:
         dendrite.close_session()

--- a/masa/utils/uids.py
+++ b/masa/utils/uids.py
@@ -7,7 +7,10 @@ from typing import List
 def check_uid_availability(
     metagraph: "bt.metagraph.Metagraph", uid: int, vpermit_tao_limit: int
 ) -> bool:
-    """Check if uid is available. The UID should be available if it is serving and has less than vpermit_tao_limit stake
+    """
+    Check if uid is available. The UID should be available if it is serving and has less
+    than vpermit_tao_limit stake
+
     Args:
         metagraph (:obj: bt.metagraph.Metagraph): Metagraph object
         uid (int): uid to be checked
@@ -18,10 +21,18 @@ def check_uid_availability(
     # Filter non serving axons.
     if not metagraph.axons[uid].is_serving:
         return False
-    # Filter validator permit > 1024 stake.
+    
+    # Filter out non validator permit.
     if metagraph.validator_permit[uid]:
+
+        # Filter out neurons who are validators
         if metagraph.S[uid] > vpermit_tao_limit:
             return False
+        
+        # Filter out uid without IP.
+        if metagraph.neurons[uid].axon_info.ip == '0.0.0.0':
+            return False
+        
     # Available otherwise.
     return True
 

--- a/masa/utils/uids.py
+++ b/masa/utils/uids.py
@@ -47,7 +47,9 @@ def get_available_uids(
     ]
 
 
-def remove_excluded_uids(uids: List[int], exclude: List[int]) -> List[int]:
+def remove_excluded_uids(uids: List[int], exclude: List[int] = None) -> List[int]:
+    if exclude is None:
+        return uids
     return [uid for uid in uids if uid not in exclude]
 
 

--- a/masa/utils/uids.py
+++ b/masa/utils/uids.py
@@ -21,28 +21,87 @@ def check_uid_availability(
     # Filter non serving axons.
     if not metagraph.axons[uid].is_serving:
         return False
-    
+
     # Filter out non validator permit.
     if metagraph.validator_permit[uid]:
 
         # Filter out neurons who are validators
         if metagraph.S[uid] > vpermit_tao_limit:
             return False
-        
+
         # Filter out uid without IP.
-        if metagraph.neurons[uid].axon_info.ip == '0.0.0.0':
+        if metagraph.neurons[uid].axon_info.ip == "0.0.0.0":
             return False
-        
+
     # Available otherwise.
     return True
+
 
 def get_available_uids(
     metagraph: "bt.metagraph.Metagraph", vpermit_tao_limit: int
 ) -> List[int]:
-    return [uid for uid in range(metagraph.n.item()) if check_uid_availability(metagraph, uid, vpermit_tao_limit)]
+    return [
+        uid
+        for uid in range(metagraph.n.item())
+        if check_uid_availability(metagraph, uid, vpermit_tao_limit)
+    ]
+
 
 def remove_excluded_uids(uids: List[int], exclude: List[int]) -> List[int]:
     return [uid for uid in uids if uid not in exclude]
+
+
+async def ping_uids(dendrite, metagraph, uids, timeout=3):
+    """
+    Pings a list of UIDs to check their availability on the Bittensor network.
+
+    Args:
+        dendrite (bittensor.dendrite): The dendrite instance to use for pinging nodes.
+        metagraph (bittensor.metagraph): The metagraph instance containing network information.
+        uids (list): A list of UIDs (unique identifiers) to ping.
+        timeout (int, optional): The timeout in seconds for each ping. Defaults to 3.
+
+    Returns:
+        tuple: A tuple containing two lists:
+            - The first list contains UIDs that were successfully pinged.
+            - The second list contains UIDs that failed to respond.
+    """
+    axons = [metagraph.axons[uid] for uid in uids]
+    try:
+        responses = await dendrite(
+            axons,
+            bt.Synapse(),  # TODO: potentially get the synapses available back?
+            deserialize=False,
+            timeout=timeout,
+        )
+        successful_uids = [
+            uid
+            for uid, response in zip(uids, responses)
+            if response.dendrite.status_code == 200
+        ]
+        failed_uids = [
+            uid
+            for uid, response in zip(uids, responses)
+            if response.dendrite.status_code != 200
+        ]
+    except Exception as e:
+        bt.logging.error(f"Dendrite ping failed: {e}")
+        successful_uids = []
+        failed_uids = uids
+    bt.logging.debug(f"ping() successful uids: {successful_uids}")
+    bt.logging.debug(f"ping() failed uids    : {failed_uids}")
+    return successful_uids, failed_uids
+
+
+def filter_duplicated_axon_ips_for_uids(uids, metagraph):
+    ips = []
+    miner_ip_filtered_uids = []
+    for uid in uids:
+        if metagraph.axons[uid].ip not in ips:
+            ips.append(metagraph.axons[uid].ip)
+            miner_ip_filtered_uids.append(uid)
+    return miner_ip_filtered_uids
+
 
 def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor:
     """Returns k available random uids from the metagraph.
@@ -59,7 +118,9 @@ def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.LongTensor
 
     print("get random uids")
 
-    avail_uids = get_available_uids(self.metagraph, self.config.neuron.vpermit_tao_limit)
+    avail_uids = get_available_uids(
+        self.metagraph, self.config.neuron.vpermit_tao_limit
+    )
     candidate_uids = remove_excluded_uids(avail_uids, exclude)
     # If k is larger than the number of available uids, set k to the number of available uids.
     k = min(k, len(avail_uids))

--- a/masa/utils/uids.py
+++ b/masa/utils/uids.py
@@ -25,10 +25,6 @@ def check_uid_availability(
     # Filter out non validator permit.
     if metagraph.validator_permit[uid]:
 
-        # Filter out neurons who are validators
-        if metagraph.S[uid] > vpermit_tao_limit:
-            return False
-
         # Filter out uid without IP.
         if metagraph.neurons[uid].axon_info.ip == "0.0.0.0":
             return False
@@ -130,13 +126,13 @@ async def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.Long
         candidate_uids = remove_excluded_uids(avail_uids, exclude)
 
         healthy_uids, _ = await ping_uids(dendrite, self.metagraph, candidate_uids)
-        filtered_uids = filter_duplicated_axon_ips_for_uids(
-            healthy_uids, self.metagraph
-        )
+        # filtered_uids = filter_duplicated_axon_ips_for_uids(
+        #     healthy_uids, self.metagraph
+        # )
 
-        k = min(k, len(filtered_uids))
+        k = min(k, len(healthy_uids))
         # Random sampling
-        random_sample = random.sample(filtered_uids, k)
+        random_sample = random.sample(healthy_uids, k)
         print(f"Random sample: {random_sample}")
 
         uids = torch.tensor(random_sample)

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -28,9 +28,9 @@ class Forwarder:
     async def forward(
         self, request, get_rewards, parser_object=None, parser_method=None, timeout=2
     ):
-        # TODO: This should live inside each endpoint to enable us to filter miners by diffferent parameters in the future
+        # TODO: This should live inside each endpoint to enable us to filter miners by different parameters in the future
         # like blacklisting miners only on a specific endpoint like profiles or followers
-        miner_uids = get_random_uids(
+        miner_uids = await get_random_uids(
             self.validator, k=self.validator.config.neuron.sample_size
         )
 

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -34,6 +34,9 @@ class Forwarder:
             self.validator, k=self.validator.config.neuron.sample_size
         )
 
+        if miner_uids is None:
+            return []
+
         responses = await self.validator.dendrite(
             axons=[self.validator.metagraph.axons[uid] for uid in miner_uids],
             synapse=request,

--- a/tests/test_template_validator.py
+++ b/tests/test_template_validator.py
@@ -37,7 +37,7 @@ class TemplateValidatorNeuronTestCase(unittest.TestCase):
     The `reward` attribute of all RewardEvents is expected to be a float, and the `is_filter_model` attribute is expected to be a boolean.
     """
 
-    def setUp(self):
+    async def setUp(self):
         sys.argv = sys.argv[0] + ["--config", "tests/configs/validator.json"]
 
         config = BaseValidatorNeuron.config()
@@ -45,7 +45,7 @@ class TemplateValidatorNeuronTestCase(unittest.TestCase):
         config.metagraph._mock = True
         config.subtensor._mock = True
         self.neuron = Validator(config)
-        self.miner_uids = get_random_uids(self, k=10)
+        self.miner_uids = await get_random_uids(self, k=10)
 
     def test_run_single_step(self):
         # TODO: Test a single step


### PR DESCRIPTION
## Related issues

- Closes #92

## Notes

Implementation heavily inspired by SN 15 - Blockchain Insight's own implementation of miner selection function ([link](https://github.com/blockchain-insights/blockchain-data-subnet/blob/c6b8d4e7e9607d0f5ed2bac24857ab1f11cf56fb/neurons/validators/utils/uids.py#L41))


## Testing

Setup:
- Local Validator on port 8091
- Local Miner on port 8092
  - Using local Oracle instance (via code) 
- Local Oracle node on port 8080

Local version control:
- Rebased branch (different name to assert changes)
- Local changes
  - Change Oracle Base URL
 
| <img src='https://github.com/masa-finance/masa-bittensor/assets/21087992/39a6d456-aa90-47a1-8638-22e30d1452c1' width='400'> |
| :--: |

### Twitter related endpoints

| _Recent Tweets_ | _Profile_ | _Followers_ |
| :--: | :--: | :--: |
| <img width="583" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/2d890618-e076-4499-acb3-d3a9553dfe36"> | <img width="582" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/e8253875-5dd1-49d5-b2bb-0d4195302036"> | <img width="577" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/0a6db072-b27b-4f7c-9b80-7a1deba1cc88"> |


### Discord related endpoints

| _Profile_ | _Channel messages_ | _Guild channel_ | _User guilds_ |
| :--: | :--: | :--: | :--: |
| <img width="576" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/d85bb77d-dc8d-4faa-858c-7015460998b3"> | <img width="642" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/4a9fb998-017c-4cc1-9e47-df017f5f1fa4"> | <img width="577" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/6419d423-c85b-4e86-a0a5-f4a58b0b77a5"> | <img width="574" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/c0cde70c-e375-4324-989d-a2c5e239c280"> |

For _all guilds_ request, oracle failed:

| _Oracle_ | _Validator_ | _Miner_ |
| :--: | :--: | :---: |
| <img width="797" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/1391cc95-060a-4b15-bf41-d33385350dfa"> | <img width="1191" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/760c7178-32c5-4572-8a5d-ac60d623b7fa"> | <img width="1177" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/1955911a-6dbe-46f4-8686-d6155ec52a01"> |

### Web scraper related endpoints

| <img width="300" alt="image" src="https://github.com/masa-finance/masa-bittensor/assets/21087992/ada27b8c-e9dc-4c71-98bf-5c532e309593"> |
| :--: |
