### PR TITLE
ci(release): add release configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: "Bug fixes :bug:"
+      labels:
+        - bug
+        - regression
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+        - ux
+        - roadmap
+    - title: 📖 Documentation and examples
+      labels:
+        - kind/documentation
+        - examples
+    - title: 👒 Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,7 +21,7 @@ changelog:
         - roadmap
     - title: 📖 Documentation and examples
       labels:
-        - kind/documentation
+        - documentation
         - examples
     - title: 👒 Dependencies
       labels:


### PR DESCRIPTION
Closes #83 .

It adds the configuration for github automated release notes generation from the labels in the PRs