### PR TITLE
ci: add commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Commitlint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    name: Commitlint
+    steps:
+      - name: Run commitlint
+        uses: opensource-nepal/commitlint@v1


### PR DESCRIPTION
This forces to have commits following the conventional commit structure by gating PRs.

In scope of #83 