### PR TITLE
ci: run commitlint checks only on PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,6 @@
 name: Commitlint
 
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
We want to only gate PRs in any case - no need to run the linter on branches