### PR TITLE
feat: publish tagged images on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Docker Build and Publish
 on:
   push:
     branches: [ "dev", "test", "main", "dockerize" ]
+  release:
+    types: [published]
 
 jobs:
   check-and-build:
@@ -17,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: Cache last successful build info
         uses: actions/cache@v3
         with:
@@ -25,7 +27,7 @@ jobs:
           key: ${{ runner.os }}-last-build-${{ matrix.image }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-last-build-${{ matrix.image }}-
-      
+
       - name: Check for changes
         id: check_changes
         run: |
@@ -36,7 +38,7 @@ jobs:
             else
               CHANGED=$(git diff --name-only $LAST_SUCCESSFUL_SHA HEAD -- docker/${{ matrix.image }} **/*.py)
             fi
-            
+          
             if [ -n "$CHANGED" ]; then
               echo "Changes detected for ${{ matrix.image }}. Building image."
               echo "changed=true" >> $GITHUB_OUTPUT
@@ -48,7 +50,7 @@ jobs:
             echo "No previous successful build found for ${{ matrix.image }}. Building image."
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Log in to GitHub Container Registry
         if: steps.check_changes.outputs.changed == 'true'
         uses: docker/login-action@v2
@@ -56,7 +58,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Build and push image
         if: steps.check_changes.outputs.changed == 'true'
         run: |
@@ -65,9 +67,10 @@ jobs:
           else
             CONTEXT="."
           fi
-          docker build -t ghcr.io/masa-finance/masa-bittensor/${{ matrix.image }}:${{ github.ref_name }} -f docker/${{ matrix.image }}/Dockerfile $CONTEXT
-          docker push ghcr.io/masa-finance/masa-bittensor/${{ matrix.image }}:${{ github.ref_name }}
-      
+          TAG=${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+          docker build -t ghcr.io/masa-finance/masa-bittensor/${{ matrix.image }}:$TAG -f docker/${{ matrix.image }}/Dockerfile $CONTEXT
+          docker push ghcr.io/masa-finance/masa-bittensor/${{ matrix.image }}:$TAG
+
       - name: Mark successful build
         if: steps.check_changes.outputs.changed == 'true'
         run: echo ${{ github.sha }} > last_successful_build_${{ matrix.image }}.txt
@@ -78,9 +81,10 @@ jobs:
     steps:
       - name: Display image tags
         run: |
+          TAG=${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
           echo "The following images may have been built and pushed:"
-          echo "ghcr.io/masa-finance/masa-bittensor/subtensor:${{ github.ref_name }}"
-          echo "ghcr.io/masa-finance/masa-bittensor/subnet:${{ github.ref_name }}"
-          echo "ghcr.io/masa-finance/masa-bittensor/miner:${{ github.ref_name }}"
-          echo "ghcr.io/masa-finance/masa-bittensor/validator:${{ github.ref_name }}"
-          echo "ghcr.io/masa-finance/masa-bittensor/protocol:${{ github.ref_name }}"
+          echo "ghcr.io/masa-finance/masa-bittensor/subtensor:$TAG"
+          echo "ghcr.io/masa-finance/masa-bittensor/subnet:$TAG"
+          echo "ghcr.io/masa-finance/masa-bittensor/miner:$TAG"
+          echo "ghcr.io/masa-finance/masa-bittensor/validator:$TAG"
+          echo "ghcr.io/masa-finance/masa-bittensor/protocol:$TAG"


### PR DESCRIPTION
## Description: Add Tagged Build and Publish for Docker Images on Release
### Summary
This PR enhances the existing GitHub Actions workflow to build and publish Docker images with a tag corresponding to the release version whenever a new release is published. This ensures that Docker images are consistently tagged with the release version, improving traceability and version management.
### Changes
1. Trigger Workflow on Release:
- Updated the on section to include the release event with the published type. This triggers the workflow whenever a new release is published.
2. Use Release Tag for Docker Images:
- Modified the Build and push image step to use the release tag (github.event.release.tag_name) as the Docker image tag if the event is a release. Otherwise, it defaults to the branch name.
3. Display Image Tags:
- Updated the display-tags job to show the correct image tags based on whether the event is a release or a push.
