### PR TITLE
feat: miner response times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ fund-validator-wallet:
 fund-miner-wallet:
 	btcli wallet faucet --wallet.name miner --subtensor.$(SUBTENSOR_ENVIRONMENT)
 
+## Send TAO
+send:
+	btcli w transfer --subtensor.$(SUBTENSOR_ENVIRONMENT)
+
 ## Subnet creation
 create-subnet:
 	btcli subnet create --wallet.name owner --subtensor.$(SUBTENSOR_ENVIRONMENT)

--- a/masa/utils/uids.py
+++ b/masa/utils/uids.py
@@ -126,6 +126,11 @@ async def get_random_uids(self, k: int, exclude: List[int] = None) -> torch.Long
         candidate_uids = remove_excluded_uids(avail_uids, exclude)
 
         healthy_uids, _ = await ping_uids(dendrite, self.metagraph, candidate_uids)
+
+        # guard against deployed validators not finding any healthy ids via ping...
+        if (len(healthy_uids) == 0):
+            healthy_uids = candidate_uids
+
         # filtered_uids = filter_duplicated_axon_ips_for_uids(
         #     healthy_uids, self.metagraph
         # )

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -29,7 +29,7 @@ class Forwarder:
         self.validator = validator
         
         
-    async def forward(self, request, get_rewards, parser_object = None, parser_method = None, timeout = 15):
+    async def forward(self, request, get_rewards, parser_object = None, parser_method = None, timeout = 10):
         miner_uids = await get_random_uids(self.validator, k=self.validator.config.neuron.sample_size)
         if miner_uids is None:
             return []
@@ -80,7 +80,7 @@ class Forwarder:
             for response, latency, uid, score in zip(parsed_responses, process_times, valid_miner_uids, rewards)
         ]
             
-        responses_with_metadata.sort(key=lambda x: (x["score"], x["latency"]), reverse=True)
+        responses_with_metadata.sort(key=lambda x: (-x["score"], x["latency"]))
         return responses_with_metadata
 
     def sanitize_responses_and_uids(self, responses, miner_uids):

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -20,9 +20,6 @@
 from masa.utils.uids import get_random_uids
 import bittensor as bt
 
-
-from masa.miner.masa_protocol_request import REQUEST_TIMEOUT_IN_SECONDS  # Import the constant
-import bittensor as bt
 # this forwarder needs to able to handle multiple requests, driven off of an API request
 class Forwarder:
     def __init__(self, validator):

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -61,7 +61,7 @@ class Forwarder:
 
         # Score responses
         rewards = get_rewards(
-            self.validator, query=request.query, responses=parsed_responses, process_times=process_times
+            self.validator, query=request.query, responses=parsed_responses
         )
 
         # Update the scores based on the rewards

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -26,7 +26,7 @@ class Forwarder:
         self.validator = validator
         
         
-    async def forward(self, request, get_rewards, parser_object = None, parser_method = None, timeout = 10):
+    async def forward(self, request, get_rewards, parser_object = None, parser_method = None, timeout = 20):
         miner_uids = await get_random_uids(self.validator, k=self.validator.config.neuron.sample_size)
         if miner_uids is None:
             return []

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -75,17 +75,13 @@ class Forwarder:
                     
 
         # Add corresponding uid to each response
-        response_with_uids = [
+        responses_with_metadata = [
             {"response": response, "uid": int(uid.item()), "score": score.item(), "latency": latency}
             for response, latency, uid, score in zip(parsed_responses, process_times, valid_miner_uids, rewards)
         ]
             
-        response_with_uids.sort(key=lambda x: x["score"], reverse=True)
-        
-        for response in response_with_uids:
-            print(response)
-        
-        return response_with_uids
+        responses_with_metadata.sort(key=lambda x: (x["score"], x["latency"]), reverse=True)
+        return responses_with_metadata
 
     def sanitize_responses_and_uids(self, responses, miner_uids):
         valid_responses = [response for response in responses if response is not None]

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -21,36 +21,36 @@ from masa.utils.uids import get_random_uids
 import bittensor as bt
 
 
+from masa.miner.masa_protocol_request import REQUEST_TIMEOUT_IN_SECONDS  # Import the constant
+import bittensor as bt
 # this forwarder needs to able to handle multiple requests, driven off of an API request
 class Forwarder:
     def __init__(self, validator):
         self.validator = validator
-
-    async def forward(
-        self, request, get_rewards, parser_object=None, parser_method=None, timeout=5
-    ):
-        # TODO: This should live inside each endpoint to enable us to filter miners by different parameters in the future
-        # like blacklisting miners only on a specific endpoint like profiles or followers
-        miner_uids = await get_random_uids(
-            self.validator, k=self.validator.config.neuron.sample_size
-        )
-
-        if miner_uids is None:
-            return []
-
-        responses = await self.validator.dendrite(
+        
+        
+    async def forward(self, request, get_rewards, parser_object = None, parser_method = None, timeout = 2):
+        ### TODO: This should live inside each endpoint to enable us to filter miners by diffferent parameters in the future
+        ### like blacklisting miners only on a specific endpoint like profiles or followers
+        miner_uids = get_random_uids(self.validator, k=self.validator.config.neuron.sample_size)
+        
+        synapses = await self.validator.dendrite(
             axons=[self.validator.metagraph.axons[uid] for uid in miner_uids],
             synapse=request,
-            deserialize=True,
-            timeout=timeout,
+            deserialize=False,
+            timeout=timeout
         )
+
+        responses = [synapse.response for synapse in synapses]
+        process_times = [synapse.dendrite.process_time for synapse in synapses]
+        bt.logging.info(f"PROCESS TIMES: {process_times}")
 
         # Filter and parse valid responses
         valid_responses, valid_miner_uids = self.sanitize_responses_and_uids(
             responses, miner_uids=miner_uids
         )
         parsed_responses = responses
-
+        
         if parser_object:
             parsed_responses = [
                 parser_object(**response) for response in valid_responses


### PR DESCRIPTION
**Description**

This PR fixes #122.  It sets up the validator forwarder to use said processing times in it's rewarding/scoring of miners.  This will be used alongside data validation to provide a weighted score. `masa/validator/forwarder.py` now includes the process time for each valid response (described as latency currently).  note that it's impact on a score has not been implemented yet.  waiting for https://github.com/masa-finance/issues/issues/197 to be implemented, and then we can use the response time as a weighted param towards the score (perhaps data validation is 0.75 weight and response time is 0.25 weight).

This PR also implements a fallback for validators when they do not find any healthy UIDs (miners) to ping.  We were seeing this behavior in our remote miners and this addresses that!  It also adds a helper command in the Makefile to send TAO 

**Notes for Reviewers**

- will wait for the work done by https://github.com/masa-finance/issues/issues/197 to complete the implementation

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits
