### PR TITLE
fix: update trigger

### DIFF
--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,6 +1,8 @@
 name: Publish Release Notes
 
 on:
+  push:
+    branches: ["main"]
   release:
     types: [published]
 


### PR DESCRIPTION
**Description**

This PR fixes an issue where our workflow automations for github release notes were not triggering when a manual release was pushed.  By adding a PUSH trigger to the automation, we are hoping that this will resolve the issue.  I will be duplicating this message so that we can get the CI to pass.

This PR fixes an issue where our workflow automations for github release notes were not triggering when a manual release was pushed.  By adding a PUSH trigger to the automation, we are hoping that this will resolve the issue.  I will be duplicating this message so that we can get the CI to pass.

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.