### PR TITLE
fix: release notes only on release

### DIFF
--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,8 +1,6 @@
 name: Publish Release Notes
 
 on:
-  push:
-    branches: ["main"]
   release:
     types: [published]
 


### PR DESCRIPTION
**Description**

This PR fixes the issue where release workflows were also including pushes to the main branch.  We only need it to be on releases!

This PR fixes the issue where release workflows were also including pushes to the main branch.  We only need it to be on releases!

This PR fixes the issue where release workflows were also including pushes to the main branch.  We only need it to be on releases!

This PR fixes the issue where release workflows were also including pushes to the main branch.  We only need it to be on releases!

This PR fixes the issue where release workflows were also including pushes to the main branch.  We only need it to be on releases!

This PR fixes the issue where release workflows were also including pushes to the main branch.  We only need it to be on releases!

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.