### PR TITLE
fix: miner versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ run-miner:
 	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
 
 run-validator:
-	watchfiles "python neurons/validator.py --neuron.disable_set_weights --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
+	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
 
 ## Docker commands
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ run-miner:
 	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
 
 run-validator:
-	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
+	watchfiles "python neurons/validator.py --neuron.disable_set_weights --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
 
 ## Docker commands
 docker-build:

--- a/docs/miner/2-clone-repository.md
+++ b/docs/miner/2-clone-repository.md
@@ -29,12 +29,6 @@ sudo apt install python3
 sudo apt install python3-venv
 python3 -m venv bittensor
 source bittensor/bin/activate
-pip install -r requirements.txt
-```
-
-```bash
-sudo apt install -y python3.10 \
-python3.10-venv && python3.10 -m venv venv && source venv/bin/activate && echo "source venv/bin/activate">>~/.bashrc
 ```
 
 ## Install required packages

--- a/docs/miner/2-clone-repository.md
+++ b/docs/miner/2-clone-repository.md
@@ -24,6 +24,15 @@ cd masa-bittensor
 ### Install Python Dependencies & Venv
 
 ```bash
+sudo apt update
+sudo apt install python3
+sudo apt install python3-venv
+python3 -m venv bittensor
+source bittensor/bin/activate
+pip install -r requirements.txt
+```
+
+```bash
 sudo apt install -y python3.10 \
 python3.10-venv && python3.10 -m venv venv && source venv/bin/activate && echo "source venv/bin/activate">>~/.bashrc
 ```

--- a/docs/miner/8-run-miner.md
+++ b/docs/miner/8-run-miner.md
@@ -14,7 +14,9 @@ export PYTHONPATH=$PYTHONPATH:$(pwd)
 ### Run Miner
 
 ```bash
-make run-miner
+sudo apt install nodejs npm
+sudo npm install -g pm2
+pm2 "make run-miner"
 ```
 
 Your miner should now be running! By default, the miner will only respond to neurons with a validator permit and at least 10 TAO staked. To adjust this configuration, you can pass the following flags to the `run-miner` command:

--- a/masa/api/validator_api.py
+++ b/masa/api/validator_api.py
@@ -36,6 +36,15 @@ class ValidatorAPI:
         )
 
         self.app.add_api_route(
+            "/versions",
+            self.validator.get_miner_versions,
+            methods=["GET"],
+            dependencies=[Depends(self.get_self)],
+            response_description="Get miner versions",
+            tags=["versions"],
+        )
+
+        self.app.add_api_route(
             "/data/twitter/profile/{username}",
             self.get_twitter_profile,
             methods=["GET"],

--- a/masa/api/validator_api.py
+++ b/masa/api/validator_api.py
@@ -36,15 +36,6 @@ class ValidatorAPI:
         )
 
         self.app.add_api_route(
-            "/versions",
-            self.validator.get_miner_versions,
-            methods=["GET"],
-            dependencies=[Depends(self.get_self)],
-            response_description="Get miner versions",
-            tags=["versions"],
-        )
-
-        self.app.add_api_route(
             "/data/twitter/profile/{username}",
             self.get_twitter_profile,
             methods=["GET"],

--- a/masa/api/validator_api.py
+++ b/masa/api/validator_api.py
@@ -141,8 +141,22 @@ class ValidatorAPI:
             response_description="Get healthcheck status",
             tags=["metagraph"],
         )
+        self.app.add_api_route(
+            "/versions",
+            self.get_miners_versions,
+            methods=["GET"],
+            dependencies=[Depends(self.get_self)],
+            response_description="Get miners versions",
+            tags=["metagraph"],
+        )
 
         self.start_server()
+
+    async def get_miners_versions(self):
+        versions = await self.validator.get_miner_versions()
+        if versions:
+            return versions
+        return []
 
     async def get_twitter_profile(self, username: str, limit: Optional[str] = None):
         all_responses = await TwitterProfileForwarder(self.validator).forward_query(

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -129,7 +129,7 @@ class BaseValidatorNeuron(BaseNeuron):
         dendrite = bt.dendrite(wallet=self.wallet)
         request = PingMiner(sent_from=get_external_ip(), is_active=False, version=0)
         responses = await dendrite(
-            self.metagraph.axons, request, deserialize=False, timeout=20
+            self.metagraph.axons, request, deserialize=False, timeout=5
         )
         self.versions = [response.version for response in responses]
         bt.logging.info(f"Axon Versions: {self.versions}")

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -128,7 +128,9 @@ class BaseValidatorNeuron(BaseNeuron):
     async def get_miner_versions(self):
         dendrite = bt.dendrite(wallet=self.wallet)
         request = PingMiner(sent_from=get_external_ip(), is_active=False, version=0)
-        responses = await dendrite(self.metagraph.axons, request, deserialize=False)
+        responses = await dendrite(
+            self.metagraph.axons, request, deserialize=False, timeout=20
+        )
         self.versions = [response.version for response in responses]
         bt.logging.info(f"Axon Versions: {self.versions}")
         self.last_version_check_block = self.block


### PR DESCRIPTION
**Description**

Problem Statement
The get_miner_versions method in the BaseValidatorNeuron class was previously designed to call all 256 miners at once. This approach could lead to significant bandwidth issues, causing network congestion and potential timeouts due to the high volume of simultaneous requests.

Solution
To address this problem, we implemented a batching mechanism within the get_miner_versions method. Instead of querying all miners at once, the method now divides the miners into smaller batches and processes each batch sequentially. This reduces the load on the network and helps prevent bandwidth-related issues.

Changes Made
Batching Requests: The miners are divided into smaller batches based on a configurable sample_size.
Sequential Processing: Each batch is processed one after the other, ensuring that the network is not overwhelmed by too many simultaneous requests.

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Masa! 
Contributing Conventions
-------------------------
The draft above helps to give a quick overview of your PR.
Remember to remove this comment and to at least:
1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
