### PR TITLE
feat: auto update

### DIFF
--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -61,6 +61,8 @@ class BaseMinerNeuron(BaseNeuron):
                 "You are allowing non-registered entities to send requests to your miner. This is a security risk."
             )
 
+        self.tempo = self.subtensor.get_subnet_hyperparameters(self.config.netuid).tempo
+
         # The axon handles request processing, allowing validators to send this miner requests.
         self.axon = bt.axon(wallet=self.wallet, config=self.config)
 

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -93,6 +93,7 @@ class BaseMinerNeuron(BaseNeuron):
         self.should_exit: bool = False
         self.is_running: bool = False
         self.thread: threading.Thread = None
+        self.auto_update_thread: threading.Thread = None
         self.lock = asyncio.Lock()
 
         self.neurons_permit_stake: Dict[str, int] = (
@@ -173,6 +174,19 @@ class BaseMinerNeuron(BaseNeuron):
         except Exception:
             bt.logging.error(traceback.format_exc())
 
+    # note, runs every tempo
+    async def run_auto_update(self):
+        while not self.should_exit:
+            try:
+                if self.config.neuron.auto_update:
+                    await self.auto_update()
+            except Exception as e:
+                bt.logging.error(f"Error running auto update: {e}")
+            await asyncio.sleep(self.tempo * 12)  # note, 12 seconds per block
+
+    def run_auto_update_in_loop(self):
+        asyncio.run(self.run_auto_update())
+
     def run_in_background_thread(self):
         """
         Starts the miner's operations in a separate background thread.
@@ -182,7 +196,11 @@ class BaseMinerNeuron(BaseNeuron):
             bt.logging.debug("Starting miner in background thread.")
             self.should_exit = False
             self.thread = threading.Thread(target=self.run, daemon=True)
+            self.auto_update_thread = threading.Thread(
+                target=self.run_auto_update_in_loop, daemon=True
+            )
             self.thread.start()
+            self.auto_update_thread.start()
             self.is_running = True
             bt.logging.debug("Started")
 
@@ -194,6 +212,7 @@ class BaseMinerNeuron(BaseNeuron):
             bt.logging.debug("Stopping miner in background thread.")
             self.should_exit = True
             self.thread.join(5)
+            self.auto_update_thread.join(5)
             self.is_running = False
             bt.logging.debug("Stopped")
 

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -18,6 +18,8 @@
 import copy
 from abc import ABC
 import bittensor as bt
+import subprocess
+import requests
 from dotenv import load_dotenv
 
 # Sync calls set weights and also resyncs the metagraph.
@@ -162,3 +164,34 @@ class BaseNeuron(ABC):
         return (
             self.block - self.metagraph.last_update[self.uid]
         ) > self.config.neuron.epoch_length and self.neuron_type != "MinerNeuron"  # don't set weights if you're a miner
+
+    def auto_update(self):
+        url = "https://api.github.com/repos/masa-finance/masa-bittensor/releases/latest"
+        response = requests.get(url)
+        data = response.json()
+        latest_commit = data["target_commitish"]
+        local_commit = subprocess.getoutput("git rev-parse HEAD")
+
+        if local_commit != latest_commit:
+            bt.logging.info("Local code is not up to date, updating...")
+            reset_cmd = "git reset --hard " + latest_commit
+            process = subprocess.Popen(reset_cmd.split(), stdout=subprocess.PIPE)
+            output, error = process.communicate()
+
+            if error:
+                bt.logging.error("Error in updating:", error)
+            else:
+                bt.logging.success(
+                    f"Updated local repo to latest version: {latest_commit}"
+                )
+                bt.logging.info("Restarting pm2 processes...")
+                restart_cmd = "pm2 restart all"
+                process = subprocess.Popen(restart_cmd.split(), stdout=subprocess.PIPE)
+                output, error = process.communicate()
+
+                if error:
+                    bt.logging.error("Error in restarting pm2 processes:", error)
+                else:
+                    bt.logging.success("Successfully restarted pm2 processes!")
+        else:
+            bt.logging.info("Repo is up-to-date.")

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -185,6 +185,7 @@ class BaseNeuron(ABC):
                     f"Updated local repo to latest version: {latest_commit}"
                 )
                 bt.logging.info("Restarting pm2 processes...")
+                # TODO, potentially improve this if the user isn't running PM2
                 restart_cmd = "pm2 restart all"
                 process = subprocess.Popen(restart_cmd.split(), stdout=subprocess.PIPE)
                 output, error = process.communicate()

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -169,6 +169,7 @@ class BaseNeuron(ABC):
         url = "https://api.github.com/repos/masa-finance/masa-bittensor/releases/latest"
         response = requests.get(url)
         data = response.json()
+        # TODO, need to somehow derive the latest commit from the release data
         latest_commit = data["target_commitish"]
         local_commit = subprocess.getoutput("git rev-parse HEAD")
 

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -77,6 +77,7 @@ class BaseValidatorNeuron(BaseNeuron):
         self.miner_ping_thread: threading.Thread = None
         self.miner_volume_thread: threading.Thread = None
         self.miner_scoring_thread: threading.Thread = None
+        self.auto_update_thread: threading.Thread = None
         self.lock = asyncio.Lock()
 
         self.run_in_background_thread()
@@ -149,6 +150,16 @@ class BaseValidatorNeuron(BaseNeuron):
             # TODO is there a better way to go about this?
             await asyncio.sleep(self.tempo / 100 * 12)
 
+    # note, runs every tempo
+    async def run_auto_update(self):
+        while not self.should_exit:
+            try:
+                if self.config.neuron.auto_update:
+                    await self.auto_update()
+            except Exception as e:
+                bt.logging.error(f"Error running auto update: {e}")
+            await asyncio.sleep(self.tempo * 12)  # note, 12 seconds per block
+
     def run_sync_in_loop(self):
         asyncio.run(self.run_sync())
 
@@ -160,6 +171,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def run_miner_scoring_in_loop(self):
         asyncio.run(self.run_miner_scoring())
+
+    def run_auto_update_in_loop(self):
+        asyncio.run(self.run_auto_update())
 
     def run_in_background_thread(self):
         """
@@ -181,10 +195,14 @@ class BaseValidatorNeuron(BaseNeuron):
             self.miner_scoring_thread = threading.Thread(
                 target=self.run_miner_scoring_in_loop, daemon=True
             )
+            self.auto_update_thread = threading.Thread(
+                target=self.run_auto_update_in_loop, daemon=True
+            )
             self.sync_thread.start()  # for setting weights, syncing metagraph,, etc
             self.miner_ping_thread.start()  # for versioning and getting keywords
             self.miner_volume_thread.start()  # for testing miner volumes
             self.miner_scoring_thread.start()  # for scoring miner volumes
+            self.auto_update_thread.start()  # for auto updating the neuron
             self.is_running = True
             bt.logging.debug("Started")
 
@@ -199,6 +217,7 @@ class BaseValidatorNeuron(BaseNeuron):
             self.miner_ping_thread.join(5)
             self.miner_volume_thread.join(5)
             self.miner_scoring_thread.join(5)
+            self.auto_update_thread.join(5)
             self.is_running = False
             bt.logging.debug("Stopped")
 
@@ -226,6 +245,7 @@ class BaseValidatorNeuron(BaseNeuron):
             self.miner_ping_thread.join(5)
             self.miner_volume_thread.join(5)
             self.miner_scoring_thread.join(5)
+            self.auto_update_thread.join(5)
             self.is_running = False
             bt.logging.debug("Stopped")
 

--- a/masa/utils/config.py
+++ b/masa/utils/config.py
@@ -99,6 +99,13 @@ def add_args(cls, parser):
     )
 
     parser.add_argument(
+        "--neuron.auto_update",
+        action="store_true",
+        help="If set, auto update the neuron on a new release.",
+        default=False,
+    )
+
+    parser.add_argument(
         "--wandb.off",
         action="store_true",
         help="Turn off wandb.",


### PR DESCRIPTION
#### Summary
This PR introduces an auto-update feature for the `BaseNeuron`, `BaseMinerNeuron`, and `BaseValidatorNeuron` classes. The feature periodically checks for updates from the GitHub repository and updates the local code if a new release is found. Additionally, it adds a new configuration option to enable or disable this auto-update functionality.

#### Changes
1. **New Dependencies**:
   - Added `subprocess` and `requests` imports to handle update checks and execution.

2. **BaseNeuron Class**:
   - Added `auto_update` method to check for the latest release on GitHub and update the local repository if necessary.

3. **BaseMinerNeuron Class**:
   - Introduced `auto_update_thread` to handle auto-updates in a separate thread.
   - Added `run_auto_update` and `run_auto_update_in_loop` methods to periodically check for updates.
   - Modified `run_in_background_thread` to start the `auto_update_thread`.
   - Modified `stop_in_background_thread` to join the `auto_update_thread`.

4. **BaseValidatorNeuron Class**:
   - Introduced `auto_update_thread` to handle auto-updates in a separate thread.
   - Added `run_auto_update` and `run_auto_update_in_loop` methods to periodically check for updates.
   - Modified `run_in_background_thread` to start the `auto_update_thread`.
   - Modified `stop_in_background_thread` to join the `auto_update_thread`.

5. **Configuration**:
   - Added a new argument `--neuron.auto_update` to enable or disable the auto-update feature.

#### Detailed Changes
```python
# masa/base/neuron.py
# ... existing code ...
import subprocess
import requests
# ... existing code ...

class BaseNeuron(ABC):
    # ... existing code ...

    def auto_update(self):
        url = "https://api.github.com/repos/masa-finance/masa-bittensor/releases/latest"
        response = requests.get(url)
        data = response.json()
        latest_commit = data["target_commitish"]
        local_commit = subprocess.getoutput("git rev-parse HEAD")

        if local_commit != latest_commit:
            bt.logging.info("Local code is not up to date, updating...")
            reset_cmd = "git reset --hard " + latest_commit
            process = subprocess.Popen(reset_cmd.split(), stdout=subprocess.PIPE)
            output, error = process.communicate()

            if error:
                bt.logging.error("Error in updating:", error)
            else:
                bt.logging.success(
                    f"Updated local repo to latest version: {latest_commit}"
                )
                bt.logging.info("Restarting pm2 processes...")
                restart_cmd = "pm2 restart all"
                process = subprocess.Popen(restart_cmd.split(), stdout=subprocess.PIPE)
                output, error = process.communicate()

                if error:
                    bt.logging.error("Error in restarting pm2 processes:", error)
                else:
                    bt.logging.success("Successfully restarted pm2 processes!")
        else:
            bt.logging.info("Repo is up-to-date.")
```

```python
# masa/base/miner.py
class BaseMinerNeuron(BaseNeuron):
    # ... existing code ...
    self.auto_update_thread: threading.Thread = None
    # ... existing code ...

    async def run_auto_update(self):
        while not self.should_exit:
            try:
                if self.config.neuron.auto_update:
                    await self.auto_update()
            except Exception as e:
                bt.logging.error(f"Error running auto update: {e}")
            await asyncio.sleep(self.tempo * 12)

    def run_auto_update_in_loop(self):
        asyncio.run(self.run_auto_update())

    def run_in_background_thread(self):
        # ... existing code ...
        self.auto_update_thread = threading.Thread(
            target=self.run_auto_update_in_loop, daemon=True
        )
        # ... existing code ...
        self.auto_update_thread.start()
        # ... existing code ...

    def stop_in_background_thread(self):
        # ... existing code ...
        self.auto_update_thread.join(5)
        # ... existing code ...
```

```python
# masa/base/validator.py
class BaseValidatorNeuron(BaseNeuron):
    # ... existing code ...
    self.auto_update_thread: threading.Thread = None
    # ... existing code ...

    async def run_auto_update(self):
        while not self.should_exit:
            try:
                if self.config.neuron.auto_update:
                    await self.auto_update()
            except Exception as e:
                bt.logging.error(f"Error running auto update: {e}")
            await asyncio.sleep(self.tempo * 12)

    def run_auto_update_in_loop(self):
        asyncio.run(self.run_auto_update())

    def run_in_background_thread(self):
        # ... existing code ...
        self.auto_update_thread = threading.Thread(
            target=self.run_auto_update_in_loop, daemon=True
        )
        # ... existing code ...
        self.auto_update_thread.start()
        # ... existing code ...

    def stop_in_background_thread(self):
        # ... existing code ...
        self.auto_update_thread.join(5)
        # ... existing code ...
```

```python
# masa/utils/config.py
def add_args(cls, parser):
    # ... existing code ...
    parser.add_argument(
        "--neuron.auto_update",
        action="store_true",
        help="If set, auto update the neuron on a new release.",
        default=False,
    )
    # ... existing code ...
```

#### Testing
- Ensure the auto-update feature works as expected by enabling the `--neuron.auto_update` flag and verifying that the neuron updates to the latest release.
- Test the background thread management to ensure no race conditions or deadlocks occur during the update process.

#### Notes
- The auto-update feature relies on the GitHub API and assumes the repository follows a specific release structure.
- The PM2 restart command is used to restart processes after an update. This may need to be adjusted based on the user's environment.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.