### PR TITLE
fix: auto-update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,17 +80,16 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug
+	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
 
 run-miner-2:
-	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey second --axon.port 8090 --neuron.debug --logging.debug
+	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey second --axon.port 8090 --neuron.debug --logging.debug" .
 
 run-miner-3:
-	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey third --axon.port 8089 --neuron.debug --logging.debug
-
+	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey third --axon.port 8089 --neuron.debug --logging.debug" .
 
 run-validator:
-	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug
+	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
 
 ## Docker commands
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-# SUBTENSOR_ENVIRONMENT = $(TESTNET)
-SUBTENSOR_ENVIRONMENT = $(MAINNET)
+SUBTENSOR_ENVIRONMENT = $(TESTNET)
+# SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-# NETUID = 165 # testnet
-NETUID = 42 # mainnet
+NETUID = 165 # testnet
+# NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,7 +80,7 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug
+	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --neuron.auto_update
 
 run-miner-2:
 	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey second --axon.port 8090 --neuron.debug --logging.debug

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-SUBTENSOR_ENVIRONMENT = $(TESTNET)
-# SUBTENSOR_ENVIRONMENT = $(MAINNET)
+# SUBTENSOR_ENVIRONMENT = $(TESTNET)
+SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-NETUID = 165 # testnet
-# NETUID = 42 # mainnet
+# NETUID = 165 # testnet
+NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,10 +80,10 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	watchfiles "python neurons/miner.py --neuron.auto_update --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
+	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
 
 run-validator:
-	watchfiles "python neurons/validator.py --neuron.auto_update --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
+	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
 
 ## Docker commands
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-SUBTENSOR_ENVIRONMENT = $(TESTNET)
-# SUBTENSOR_ENVIRONMENT = $(MAINNET)
+# SUBTENSOR_ENVIRONMENT = $(TESTNET)
+SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-NETUID = 165 # testnet
-# NETUID = 42 # mainnet
+# NETUID = 165 # testnet
+NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,7 +80,7 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --neuron.auto_update
+	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug
 
 run-miner-2:
 	python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey second --axon.port 8090 --neuron.debug --logging.debug

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-# SUBTENSOR_ENVIRONMENT = $(TESTNET)
-SUBTENSOR_ENVIRONMENT = $(MAINNET)
+SUBTENSOR_ENVIRONMENT = $(TESTNET)
+# SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-# NETUID = 165 # testnet
-NETUID = 42 # mainnet
+NETUID = 165 # testnet
+# NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,16 +80,10 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
-
-run-miner-2:
-	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey second --axon.port 8090 --neuron.debug --logging.debug" .
-
-run-miner-3:
-	watchfiles "python neurons/miner.py --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey third --axon.port 8089 --neuron.debug --logging.debug" .
+	watchfiles "python neurons/miner.py --neuron.auto_update --blacklist.force_validator_permit --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug" .
 
 run-validator:
-	watchfiles "python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
+	watchfiles "python neurons/validator.py --neuron.auto_update --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug" .
 
 ## Docker commands
 docker-build:

--- a/masa/base/miner.py
+++ b/masa/base/miner.py
@@ -181,7 +181,7 @@ class BaseMinerNeuron(BaseNeuron):
         while not self.should_exit:
             try:
                 if self.config.neuron.auto_update:
-                    await self.auto_update()
+                    self.auto_update()
             except Exception as e:
                 bt.logging.error(f"Error running auto update: {e}")
             await asyncio.sleep(self.tempo * 12)  # note, 12 seconds per block

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -170,7 +170,7 @@ class BaseNeuron(ABC):
             self.block - self.metagraph.last_update[self.uid]
         ) > self.config.neuron.epoch_length and self.neuron_type != "MinerNeuron"  # don't set weights if you're a miner
 
-    def auto_update(self):
+    async def auto_update(self):
         url = "https://api.github.com/repos/masa-finance/masa-bittensor/releases/latest"
         response = requests.get(url)
         data = response.json()
@@ -179,8 +179,7 @@ class BaseNeuron(ABC):
         # Get the current local tag
         local_tag = subprocess.getoutput("git describe --tags --abbrev=0").strip()
 
-        bt.logging.success(f"Local tag: {local_tag}")
-        bt.logging.success(f"Latest tag: {latest_tag}")
+        bt.logging.info(f"Local tag: {local_tag}, Latest tag: {latest_tag}")
 
         if local_tag != latest_tag:
             bt.logging.info(

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -108,7 +108,7 @@ class BaseNeuron(ABC):
         ).weights_version
         if self.spec_version < weights_version:
             bt.logging.warning(
-                f"🟡 Code version required by hyperparameter is not met!  Required: {weights_version}, Current: {self.spec_version}"
+                f"🟡 Code version required by hyperparameter is not met!  Required: {weights_version}, Current: {self.spec_version}.  Please update your code to the latest release!"
             )
         else:
             bt.logging.success(
@@ -172,8 +172,7 @@ class BaseNeuron(ABC):
             self.block - self.metagraph.last_update[self.uid]
         ) > self.config.neuron.epoch_length and self.neuron_type != "MinerNeuron"  # don't set weights if you're a miner
 
-    # TODO ask about async / await in python
-    async def auto_update(self):
+    def auto_update(self):
         url = "https://api.github.com/repos/masa-finance/masa-bittensor/releases/latest"
         response = requests.get(url)
         data = response.json()
@@ -197,7 +196,7 @@ class BaseNeuron(ABC):
 
             if current_commit != latest_tag_commit:
                 bt.logging.warning(
-                    f"Local code is not up to date (local commit: {current_commit}, latest tag commit: {latest_tag_commit}), updating..."
+                    f"🟡 Local code is not up to date with latest tag, updating to {latest_tag}..."
                 )
                 # Fetch all tags from the remote repository
                 subprocess.run(["git", "fetch", "--tags"], check=True)
@@ -208,7 +207,7 @@ class BaseNeuron(ABC):
                     f"Updated local repo to latest version: {latest_tag}"
                 )
             else:
-                bt.logging.success("Repo is up-to-date.")
+                bt.logging.success(f"🟢 Code matches latest release: {latest_tag}")
         except subprocess.CalledProcessError as e:
             bt.logging.error(f"Subprocess error: {e}")
         except Exception as e:

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -189,16 +189,7 @@ class BaseNeuron(ABC):
             subprocess.run(["git", "fetch", "--tags"], check=True)
             # Checkout the latest tag
             subprocess.run(["git", "checkout", latest_tag], check=True)
+            # Watchfiles should now trigger...
             bt.logging.success(f"Updated local repo to latest version: {latest_tag}")
-            bt.logging.info("Restarting pm2 processes...")
-            # Restart PM2 processes (if applicable)
-            restart_cmd = "pm2 restart all"
-            process = subprocess.Popen(restart_cmd.split(), stdout=subprocess.PIPE)
-            output, error = process.communicate()
-
-            if error:
-                bt.logging.error(f"Error in restarting pm2 processes: {error}")
-            else:
-                bt.logging.success("Successfully restarted pm2 processes!")
         else:
             bt.logging.info("Repo is up-to-date.")

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -108,10 +108,12 @@ class BaseNeuron(ABC):
         ).weights_version
         if self.spec_version < weights_version:
             bt.logging.warning(
-                f"🟡 Code Is Outdated! Latest: {weights_version}, Local: {self.spec_version}"
+                f"🟡 Code version required by hyperparameter is not met!  Required: {weights_version}, Current: {self.spec_version}"
             )
         else:
-            bt.logging.success(f"🟢 Code Is Up To Date! Version: {self.spec_version}")
+            bt.logging.success(
+                f"🟢 Code is up to date based on hyperparameter requirements: {self.spec_version}"
+            )
 
         # Each miner gets a unique identity (UID) in the network for differentiation.
         self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -108,11 +108,11 @@ class BaseNeuron(ABC):
         ).weights_version
         if self.spec_version < weights_version:
             bt.logging.warning(
-                f"🟡 Code version required by hyperparameter is not met!  Required: {weights_version}, Current: {self.spec_version}.  Please update your code to the latest release!"
+                f"🟡 Code is outdated based on subnet requirements!  Required: {weights_version}, Current: {self.spec_version}.  Please update your code to the latest release!"
             )
         else:
             bt.logging.success(
-                f"🟢 Code is up to date based on hyperparameter requirements: {self.spec_version}"
+                f"🟢 Code is up to date based on subnet requirements: {self.spec_version}"
             )
 
         # Each miner gets a unique identity (UID) in the network for differentiation.

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -30,6 +30,9 @@ from masa.base.neuron import BaseNeuron
 from masa.utils.config import add_validator_args
 from masa.mock import MockDendrite
 
+from masa.validator.scorer import Scorer
+from masa.validator.forwarder import Forwarder
+
 
 class BaseValidatorNeuron(BaseNeuron):
     """
@@ -45,6 +48,9 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def __init__(self, config=None):
         super().__init__(config=config)
+
+        self.forwarder = Forwarder(self)
+        self.scorer = Scorer(self)
 
         self.hotkeys = copy.deepcopy(self.metagraph.hotkeys)
         self.tempo = self.subtensor.get_subnet_hyperparameters(self.config.netuid).tempo

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -160,7 +160,7 @@ class BaseValidatorNeuron(BaseNeuron):
         while not self.should_exit:
             try:
                 if self.config.neuron.auto_update:
-                    await self.auto_update()
+                    self.auto_update()
             except Exception as e:
                 bt.logging.error(f"Error running auto update: {e}")
             await asyncio.sleep(self.tempo * 12)  # note, 12 seconds per block

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -24,9 +24,6 @@ from masa.base.validator import BaseValidatorNeuron
 from masa.api.server import API
 from sentence_transformers import SentenceTransformer
 
-from masa.validator.scorer import Scorer
-from masa.validator.forwarder import Forwarder
-
 
 class Validator(BaseValidatorNeuron):
     def __init__(self, config=None):
@@ -34,8 +31,6 @@ class Validator(BaseValidatorNeuron):
         self.model = SentenceTransformer(
             "all-MiniLM-L6-v2"
         )  # Load a pre-trained model for embeddings
-        self.forwarder = Forwarder(self)
-        self.scorer = Scorer(self)
         if (
             hasattr(self.config, "enable_validator_api")
             and self.config.enable_validator_api

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ torch==2.3.0
 scikit-learn==1.5.1
 sentence-transformers==3.0.1
 pytest
+watchfiles


### PR DESCRIPTION
**Description**

This pull request implements a change in how we manage versioning and updates within the Bittensor project. We are transitioning from using commit hashes to Git tags for the following reasons:

1. **Clarity and Readability**:
   - **Git Tags**: Tags provide a human-readable versioning system (e.g., `v3.4.0`), making it easier to identify and reference specific releases.
   - **Commit Hashes**: Previously, we relied on commit hashes, which are less intuitive and harder to track for specific versions.

2. **Consistency with Releases**:
   - **Git Tags**: Tags are directly associated with releases on GitHub, ensuring that each release corresponds to a specific, immutable point in the repository's history.
   - **Commit Hashes**: Using commit hashes could lead to inconsistencies, as they are not inherently tied to release events.

3. **Simplified Update Process**:
   - **Git Tags**: The `auto_update()` function now fetches the latest release tag, simplifying the process of ensuring the local codebase is up-to-date with the latest stable release.
   - **Commit Hashes**: The previous method required additional steps to determine the correct commit associated with a release.

4. **Improved Automation**:
   - **Git Tags**: Our CI/CD workflows are now better aligned with GitHub's release process, allowing for automated updates and deployments based on tags.
   - **Commit Hashes**: Automation was more complex and error-prone when relying on commit hashes.

**Changes Made**:
- Updated the `auto_update()` function to fetch and compare Git tags instead of commit hashes.

This change enhances our version control strategy, making it more robust and user-friendly. It aligns with best practices for software release management and ensures a smoother development workflow.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.