### PR TITLE
fix: upgrade to bittensor 8.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-# SUBTENSOR_ENVIRONMENT = $(TESTNET)
-SUBTENSOR_ENVIRONMENT = $(MAINNET)
+SUBTENSOR_ENVIRONMENT = $(TESTNET)
+# SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-# NETUID = 165 # testnet
-NETUID = 42 # mainnet
+NETUID = 165 # testnet
+# NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-SUBTENSOR_ENVIRONMENT = $(TESTNET)
-# SUBTENSOR_ENVIRONMENT = $(MAINNET)
+# SUBTENSOR_ENVIRONMENT = $(TESTNET)
+SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-NETUID = 165 # testnet
-# NETUID = 42 # mainnet
+# NETUID = 165 # testnet
+NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####

--- a/masa/__init__.py
+++ b/masa/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the code version for miners / validators.  This must match weights_version on the subnet!  If not, validators won't be able to set weights, and miners will get a warning.
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (100 * int(version_split[0]))

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -27,7 +27,6 @@ from masa.utils.config import check_config, add_args, config
 from masa.utils.misc import ttl_get_block
 from masa import __spec_version__ as spec_version
 from masa.mock import MockSubtensor, MockMetagraph
-from bittensor_wallet import Config
 
 # Load the .env file for each neuron that tries to run the code
 load_dotenv()
@@ -92,12 +91,7 @@ class BaseNeuron(ABC):
             self.subtensor = MockSubtensor(self.config.netuid, wallet=self.wallet)
             self.metagraph = MockMetagraph(self.config.netuid, subtensor=self.subtensor)
         else:
-            wallet_specific_config = Config(
-                hotkey=self.config.wallet.hotkey,
-                name=self.config.wallet.name,
-                path=self.config.wallet.path,
-            )
-            self.wallet = bt.wallet(config=wallet_specific_config)
+            self.wallet = bt.wallet(config=self.config)
             self.subtensor = bt.subtensor(config=self.config)
             self.metagraph = self.subtensor.metagraph(self.config.netuid)
 

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -35,6 +35,7 @@ from masa.validator.forwarder import Forwarder
 from sentence_transformers import SentenceTransformer
 
 from masa.types.twitter import ProtocolTwitterTweetResponse
+from masa.utils.weights import process_weights_for_netuid
 
 
 class BaseValidatorNeuron(BaseNeuron):
@@ -324,7 +325,7 @@ class BaseValidatorNeuron(BaseNeuron):
         (
             processed_weight_uids,
             processed_weights,
-        ) = bt.utils.weight_utils.process_weights_for_netuid(
+        ) = process_weights_for_netuid(
             uids=self.metagraph.uids,
             weights=raw_weights.to("cpu").numpy(),
             netuid=self.config.netuid,

--- a/masa/utils/weights.py
+++ b/masa/utils/weights.py
@@ -17,22 +17,20 @@
 
 """Conversion for weight between chain representation and np.array or torch.Tensor"""
 
-import hashlib
 import logging
 import typing
-import bittensor as bt
 from typing import Union, Optional
 
 import numpy as np
 
 from numpy.typing import NDArray
 
-from bt.utils.btlogging import logging
-from bt.utils.registration import torch, use_torch
+from bittensor.utils.btlogging import logging
+from bittensor.utils.registration import torch, use_torch
 
 if typing.TYPE_CHECKING:
-    from bt.core.metagraph import Metagraph
-    from bt.core.subtensor import Subtensor
+    from bittensor.core.metagraph import Metagraph
+    from bittensor.core.subtensor import Subtensor
 
 
 U16_MAX = 65535

--- a/masa/utils/weights.py
+++ b/masa/utils/weights.py
@@ -1,0 +1,170 @@
+# The MIT License (MIT)
+# Copyright © 2024 Opentensor Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+"""Conversion for weight between chain representation and np.array or torch.Tensor"""
+
+import hashlib
+import logging
+import typing
+import bittensor as bt
+from typing import Union, Optional
+
+import numpy as np
+
+from numpy.typing import NDArray
+
+from bt.utils.btlogging import logging
+from bt.utils.registration import torch, use_torch
+
+if typing.TYPE_CHECKING:
+    from bt.core.metagraph import Metagraph
+    from bt.core.subtensor import Subtensor
+
+
+U16_MAX = 65535
+
+
+# The community uses / bittensor does not
+def process_weights_for_netuid(
+    uids: Union[NDArray[np.int64], "torch.Tensor"],
+    weights: Union[NDArray[np.float32], "torch.Tensor"],
+    netuid: int,
+    subtensor: "Subtensor",
+    metagraph: Optional["Metagraph"] = None,
+    exclude_quantile: int = 0,
+) -> Union[
+    tuple["torch.Tensor", "torch.FloatTensor"],
+    tuple[NDArray[np.int64], NDArray[np.float32]],
+]:
+    """
+    Processes weight tensors for a given subnet id using the provided weight and UID arrays, applying constraints and normalization based on the subtensor and metagraph data. This function can handle both NumPy arrays and PyTorch tensors.
+
+    Args:
+        uids (Union[NDArray[np.int64], "torch.Tensor"]): Array of unique identifiers of the neurons.
+        weights (Union[NDArray[np.float32], "torch.Tensor"]): Array of weights associated with the user IDs.
+        netuid (int): The network uid to process weights for.
+        subtensor (Subtensor): Subtensor instance to access blockchain data.
+        metagraph (Optional[Metagraph]): Metagraph instance for additional network data. If None, it is fetched from the subtensor using the netuid.
+        exclude_quantile (int): Quantile threshold for excluding lower weights. Defaults to ``0``.
+
+    Returns:
+        Union[tuple["torch.Tensor", "torch.FloatTensor"], tuple[NDArray[np.int64], NDArray[np.float32]]]: tuple containing the array of user IDs and the corresponding normalized weights. The data type of the return matches the type of the input weights (NumPy or PyTorch).
+    """
+
+    logging.debug("process_weights_for_netuid()")
+    logging.debug("weights", weights)
+    logging.debug("netuid", netuid)
+    logging.debug("subtensor", subtensor)
+    logging.debug("metagraph", metagraph)
+
+    # Get latest metagraph from chain if metagraph is None.
+    if metagraph is None:
+        metagraph = subtensor.metagraph(netuid)
+
+    # Cast weights to floats.
+    if use_torch():
+        if not isinstance(weights, torch.FloatTensor):
+            weights = weights.type(torch.float32)
+    else:
+        if not isinstance(weights, np.float32):
+            weights = weights.astype(np.float32)
+
+    # Network configuration parameters from an subtensor.
+    # These parameters determine the range of acceptable weights for each neuron.
+    quantile = exclude_quantile / U16_MAX
+    min_allowed_weights = subtensor.min_allowed_weights(netuid=netuid)
+    max_weight_limit = subtensor.max_weight_limit(netuid=netuid)
+    logging.debug("quantile", quantile)
+    logging.debug("min_allowed_weights", min_allowed_weights)
+    logging.debug("max_weight_limit", max_weight_limit)
+
+    # Find all non zero weights.
+    non_zero_weight_idx = (
+        torch.argwhere(weights > 0).squeeze(dim=1)
+        if use_torch()
+        else np.argwhere(weights > 0).squeeze(axis=1)
+    )
+    non_zero_weight_uids = uids[non_zero_weight_idx]
+    non_zero_weights = weights[non_zero_weight_idx]
+    nzw_size = non_zero_weights.numel() if use_torch() else non_zero_weights.size
+    if nzw_size == 0 or metagraph.n < min_allowed_weights:
+        logging.warning("No non-zero weights returning all ones.")
+        final_weights = (
+            torch.ones((metagraph.n)).to(metagraph.n) / metagraph.n
+            if use_torch()
+            else np.ones((metagraph.n), dtype=np.int64) / metagraph.n
+        )
+        logging.debug("final_weights", final_weights)
+        final_weights_count = (
+            torch.tensor(list(range(len(final_weights))))
+            if use_torch()
+            else np.arange(len(final_weights))
+        )
+        return (
+            (final_weights_count, final_weights)
+            if use_torch()
+            else (final_weights_count, final_weights)
+        )
+
+    elif nzw_size < min_allowed_weights:
+        logging.warning(
+            "No non-zero weights less then min allowed weight, returning all ones."
+        )
+        # ( const ): Should this be np.zeros( ( metagraph.n ) ) to reset everyone to build up weight?
+        weights = (
+            torch.ones((metagraph.n)).to(metagraph.n) * 1e-5
+            if use_torch()
+            else np.ones((metagraph.n), dtype=np.int64) * 1e-5
+        )  # creating minimum even non-zero weights
+        weights[non_zero_weight_idx] += non_zero_weights
+        logging.debug("final_weights", *weights)
+        nw_arange = (
+            torch.tensor(list(range(len(non_zero_weights))))
+            if use_torch()
+            else np.arange(len(non_zero_weights))
+        )
+        return nw_arange, non_zero_weights
+
+    logging.debug("non_zero_weights", *non_zero_weights)
+
+    # Compute the exclude quantile and find the weights in the lowest quantile
+    max_exclude = max(0, len(non_zero_weights) - min_allowed_weights) / len(
+        non_zero_weights
+    )
+    exclude_quantile = min([quantile, max_exclude])
+    lowest_quantile = (
+        non_zero_weights.quantile(exclude_quantile)
+        if use_torch()
+        else np.quantile(non_zero_weights, exclude_quantile)
+    )
+    logging.debug("max_exclude", max_exclude)
+    logging.debug("exclude_quantile", exclude_quantile)
+    logging.debug("lowest_quantile", lowest_quantile)
+
+    # Exclude all weights below the allowed quantile.
+    non_zero_weight_uids = non_zero_weight_uids[lowest_quantile <= non_zero_weights]
+    non_zero_weights = non_zero_weights[lowest_quantile <= non_zero_weights]
+    logging.debug("non_zero_weight_uids", *non_zero_weight_uids)
+    logging.debug("non_zero_weights", *non_zero_weights)
+
+    # Normalize weights and return.
+    # normalized_weights = normalize_max_weight(
+    #     x=non_zero_weights, limit=max_weight_limit
+    # )
+    logging.debug("final_weights", non_zero_weights)
+
+    return non_zero_weight_uids, non_zero_weights

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["masa"]
 
 [project]
 name = "masa"
-version = "1.0.1"
+version = "1.0.2"
 description = "bittensor subnet for masa protocol"
 authors = [
     { name = "masa.ai", email = "hello@masa.ai" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "bittensor==8.1.1",
+    "bittensor==8.2.0",
     "loguru==0.7.2",
     "python-dotenv==0.21.0",
     "torch==2.3.0",


### PR DESCRIPTION
**Description**

This PR upgrades to Bittensor 8.2.0 and in the process solves a few bug fixes that were present when doing so, namely changes to the code that supported Bittensor 8.1.1

- Removes the special wallet Config in `masa/base/neuron.py` in favor of passing `self.config` directly to the wallet.
- Ports the `process_weights_for_netuid` function from the Bittensor library into the codebase for refined control / ensuring that weights can be set at all times.
- Adds `weights.py` file to `masa/utils` to support comment above
- Bumps package version in our `pyproject.toml`

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Masa! 
Contributing Conventions
-------------------------
The draft above helps to give a quick overview of your PR.
Remember to remove this comment and to at least:
1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
