### PR TITLE
fix: setting weights

### DIFF
--- a/masa/utils/weights.py
+++ b/masa/utils/weights.py
@@ -33,7 +33,6 @@ if typing.TYPE_CHECKING:
     from bittensor.core.subtensor import Subtensor
 
 
-U32_MAX = 4294967295
 U16_MAX = 65535
 
 

--- a/masa/utils/weights.py
+++ b/masa/utils/weights.py
@@ -33,9 +33,11 @@ if typing.TYPE_CHECKING:
     from bittensor.core.subtensor import Subtensor
 
 
+U32_MAX = 4294967295
 U16_MAX = 65535
 
 
+# Uses in `bittensor.utils.weight_utils.process_weights_for_netuid`
 @legacy_torch_api_compat
 def normalize_max_weight(
     x: Union[NDArray[np.float32], "torch.FloatTensor"], limit: float = 0.1
@@ -154,7 +156,7 @@ def process_weights_for_netuid(
             if use_torch()
             else np.ones((metagraph.n), dtype=np.int64) / metagraph.n
         )
-        logging.debug("final_weights", final_weights)
+        # logging.debug("final_weights", final_weights)
         final_weights_count = (
             torch.tensor(list(range(len(final_weights))))
             if use_torch()
@@ -177,7 +179,7 @@ def process_weights_for_netuid(
             else np.ones((metagraph.n), dtype=np.int64) * 1e-5
         )  # creating minimum even non-zero weights
         weights[non_zero_weight_idx] += non_zero_weights
-        logging.debug("final_weights", *weights)
+        # logging.debug("final_weights", *weights)
         normalized_weights = normalize_max_weight(x=weights, limit=max_weight_limit)
         nw_arange = (
             torch.tensor(list(range(len(normalized_weights))))
@@ -186,7 +188,7 @@ def process_weights_for_netuid(
         )
         return nw_arange, normalized_weights
 
-    logging.debug("non_zero_weights", *non_zero_weights)
+    # logging.debug("non_zero_weights", *non_zero_weights)
 
     # Compute the exclude quantile and find the weights in the lowest quantile
     max_exclude = max(0, len(non_zero_weights) - min_allowed_weights) / len(
@@ -205,13 +207,13 @@ def process_weights_for_netuid(
     # Exclude all weights below the allowed quantile.
     non_zero_weight_uids = non_zero_weight_uids[lowest_quantile <= non_zero_weights]
     non_zero_weights = non_zero_weights[lowest_quantile <= non_zero_weights]
-    logging.debug("non_zero_weight_uids", *non_zero_weight_uids)
-    logging.debug("non_zero_weights", *non_zero_weights)
+    # logging.debug("non_zero_weight_uids", *non_zero_weight_uids)
+    # logging.debug("non_zero_weights", *non_zero_weights)
 
     # Normalize weights and return.
     normalized_weights = normalize_max_weight(
         x=non_zero_weights, limit=max_weight_limit
     )
-    logging.debug("final_weights", non_zero_weights)
+    # logging.debug("final_weights", normalized_weights)
 
-    return non_zero_weight_uids, non_zero_weights
+    return non_zero_weight_uids, normalized_weights


### PR DESCRIPTION
**Description**

This PR fixes this issue with validators sometimes not being able to set weights.  The issue was traced down to logging bugs in the Bittensor library.

Sometimes the library was calling `bt.logging.info("Weights", weights)`, where it needs to be `bt.logging.info("Weights", *weights)`.

The resolve has been to copy the relevant logic into the subnet code, and comment out the logging bugs.

After testing on testnet, validators are able to set weights even if no scores have been marked.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Masa! 
Contributing Conventions
-------------------------
The draft above helps to give a quick overview of your PR.
Remember to remove this comment and to at least:
1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
