### PR TITLE
feat: reduce randomness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ run-miner:
 	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit --twitter.max_tweets_per_request 10
 
 run-validator:
-	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off
+	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off --enable_validator_api
 
 ## Docker commands
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-# SUBTENSOR_ENVIRONMENT = $(TESTNET)
-SUBTENSOR_ENVIRONMENT = $(MAINNET)
+SUBTENSOR_ENVIRONMENT = $(TESTNET)
+# SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-# NETUID = 165 # testnet
-NETUID = 42 # mainnet
+NETUID = 165 # testnet
+# NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,7 +80,7 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit
+	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit --twitter.max_tweets_per_request 10
 
 run-validator:
 	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-SUBTENSOR_ENVIRONMENT = $(TESTNET)
-# SUBTENSOR_ENVIRONMENT = $(MAINNET)
+# SUBTENSOR_ENVIRONMENT = $(TESTNET)
+SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-NETUID = 165 # testnet
-# NETUID = 42 # mainnet
+# NETUID = 165 # testnet
+NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,10 +80,10 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit --twitter.max_tweets_per_request 10
+	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit
 
 run-validator:
-	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off --enable_validator_api
+	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off
 
 ## Docker commands
 docker-build:

--- a/masa/api/server.py
+++ b/masa/api/server.py
@@ -49,52 +49,6 @@ class API:
             tags=["twitter"],
         )
 
-        # self.app.add_api_route(
-        #     "/data/discord/profile",
-        #     self.validator.forwarder.get_discord_profile,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord profile for the given user ID",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/channels/{channel_id}/messages",
-        #     self.validator.forwarder.get_discord_channel_messages,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord channel messages for the given channel ID",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/guilds/{guild_id}/channels",
-        #     self.validator.forwarder.get_discord_guild_channels,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord channels for the given guild ID",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/user/guilds",
-        #     self.validator.forwarder.get_discord_user_guilds,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord guilds for the user",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/guilds/all",
-        #     self.validator.forwarder.get_discord_all_guilds,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get all guilds that all the Discord workers are apart of",
-        #     tags=["discord"],
-        # )
-
-        # note, healthcheck for the validator
         self.app.add_api_route(
             "/healthcheck",
             self.healthcheck,
@@ -131,27 +85,6 @@ class API:
             tags=["scoring"],
         )
 
-        # note, only for testing / wiping state
-        # self.app.add_api_route(
-        #     "/volumes",
-        #     self.delete_miner_volumes,
-        #     methods=["DELETE"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Delete volumes state",
-        #     tags=["scoring"],
-        # )
-
-        # note, only for testing, this also runs on a dedciated thread
-        # self.app.add_api_route(
-        #     "/score",
-        #     self.validator.scorer.score_miner_volumes,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Score miner volumes",
-        #     tags=["scoring"],
-        # )
-
-        # note, show the scores the validator has computed
         self.app.add_api_route(
             "/scores",
             self.show_scores,
@@ -162,23 +95,22 @@ class API:
         )
 
         self.app.add_api_route(
-            "/tweets",
-            self.show_indexed_tweets,
+            "/tweets_by_query",
+            self.show_tweets_by_query,
             methods=["GET"],
             dependencies=[Depends(self.get_self)],
-            response_description="Get indexed tweets",
+            response_description="Get indexed tweets by query",
             tags=["data"],
         )
 
-        # note, only for testing / wiping state
-        # self.app.add_api_route(
-        #     "/tweets",
-        #     self.delete_indexed_tweets,
-        #     methods=["DELETE"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Delete indexed tweets",
-        #     tags=["data"],
-        # )
+        self.app.add_api_route(
+            "/tweets_by_uid",
+            self.show_tweets_by_uid,
+            methods=["GET"],
+            dependencies=[Depends(self.get_self)],
+            response_description="Get indexed tweets by UID",
+            tags=["data"],
+        )
 
         self.start_server()
 
@@ -201,29 +133,20 @@ class API:
             return JSONResponse(content=scores.tolist())
         return JSONResponse(content=[])
 
-    async def show_indexed_tweets(self):
-        tweets = self.validator.indexed_tweets
+    async def show_tweets_by_query(self):
+        tweets = self.validator.tweets_by_query
         if len(tweets) > 0:
             return JSONResponse(content=tweets)
         return JSONResponse(content=[])
 
-    def delete_miner_volumes(self):
-        self.validator.volumes = []
-        return JSONResponse(
-            content={
-                "message": "Volumes state deleted",
-                "volumes": self.validator.volumes,
+    async def show_tweets_by_uid(self):
+        tweets = self.validator.tweets_by_uid
+        if len(tweets) > 0:
+            serializable_tweets = {
+                uid: list(tweet_set) for uid, tweet_set in tweets.items()
             }
-        )
-
-    def delete_indexed_tweets(self):
-        self.validator.indexed_tweets = []
-        return JSONResponse(
-            content={
-                "message": "Index tweets deleted",
-                "volumes": self.validator.indexed_tweets,
-            }
-        )
+            return JSONResponse(content=serializable_tweets)
+        return JSONResponse(content=[])
 
     def get_axons(self):
         return self.validator.metagraph.axons

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -111,6 +111,7 @@ class BaseValidatorNeuron(BaseNeuron):
         self.keyword = ""  # note, current keyword
         self.keywords = []  # note, for volume scoring queries
         self.uncalled_uids = set()  # note, for volume scoring queries
+        self.volume_window = 6  # note, score volumes from last 6 tempos
 
         if self.config.subtensor._mock:
             self.dendrite = MockDendrite(wallet=self.wallet)
@@ -382,7 +383,7 @@ class BaseValidatorNeuron(BaseNeuron):
             if hotkey != self.metagraph.hotkeys[uid]:
                 self.scores[uid] = 0  # hotkey has been replaced
                 # Take the last 6 objects in the self.volumes list
-                recent_volumes = self.volumes[-6:]
+                recent_volumes = self.volumes[-self.volume_window :]
                 # Replace all instances of miners[uid] and set their values to 0
                 for volume in recent_volumes:
                     if uid in volume["miners"]:

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -157,9 +157,9 @@ class Forwarder:
             self.validator.keyword = random.choice(self.validator.keywords)
 
         yesterday = datetime.now(UTC) - timedelta(days=1)
-        query = f"({self.validator.keyword.strip()}) since:{yesterday.strftime(
+        query = f'("{self.validator.keyword.strip()}") since:{yesterday.strftime(
             "%Y-%m-%d"
-        )}"
+        )}'
         bt.logging.info(f"Volume checking for: {query}")
 
         volume_checking_timeout = 20

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -153,11 +153,9 @@ class Forwarder:
         if len(self.validator.keywords) == 0 or self.check_tempo():
             await self.fetch_twitter_queries()
 
-        if not self.validator.keyword or len(self.validator.uncalled_uids) == 0:
-            self.validator.keyword = random.choice(self.validator.keywords)
-
+        random_keyword = random.choice(self.validator.keywords)
         yesterday = datetime.now(UTC) - timedelta(days=1)
-        query = f'("{self.validator.keyword.strip()}") since:{yesterday.strftime(
+        query = f'("{random_keyword.strip()}") since:{yesterday.strftime(
             "%Y-%m-%d"
         )}'
         bt.logging.info(f"Volume checking for: {query}")
@@ -179,13 +177,13 @@ class Forwarder:
             if not all_responses:
                 continue
 
-            unique_tweets_response = []
-            existing_ids = set()
-            for resp in all_responses:
-                tweet_id = resp.get("Tweet", {}).get("ID")
-                if tweet_id and tweet_id not in existing_ids:
-                    unique_tweets_response.append(resp)
-                    existing_ids.add(tweet_id)
+            unique_tweets_response = list(
+                {
+                    resp["Tweet"]["ID"]: resp
+                    for resp in all_responses
+                    if "Tweet" in resp and "ID" in resp["Tweet"]
+                }.values()
+            )
 
             if unique_tweets_response is not None:
                 # note, first spot check this payload, ensuring a random tweet is valid
@@ -203,7 +201,7 @@ class Forwarder:
                 )
 
                 query_words = (
-                    self.normalize_whitespace(self.validator.keyword.replace('"', ""))
+                    self.normalize_whitespace(random_keyword.replace('"', ""))
                     .strip()
                     .lower()
                     .split()
@@ -231,7 +229,7 @@ class Forwarder:
 
                 if not query_in_tweet:
                     bt.logging.warning(
-                        f"Query: {self.validator.keyword} is not in the tweet: {fields_to_check}"
+                        f"Query: {random_keyword} is not in the tweet: {fields_to_check}"
                     )
 
                 tweet_timestamp = datetime.fromtimestamp(
@@ -248,7 +246,7 @@ class Forwarder:
                 # note, they passed the spot check!
                 if is_valid and query_in_tweet and is_since_date_requested:
                     bt.logging.success(
-                        f"Miner {uid} passed the spot check with query: {self.validator.keyword}"
+                        f"Miner {uid} passed the spot check with query: {random_keyword}"
                     )
                     for tweet in unique_tweets_response:
                         if tweet:
@@ -259,42 +257,56 @@ class Forwarder:
                                     tweet_embedding,
                                 )
                             )
-                            if similarity >= 60:  # pretty strict
+                            if similarity >= 70:  # pretty strict
                                 valid_tweets.append(tweet)
                 else:
                     bt.logging.warning(f"Miner {uid} failed the spot check!")
 
-            self.validator.scorer.add_volume(int(uid), len(valid_tweets))
-            bt.logging.info(f"Miner {uid} produced {len(valid_tweets)} valid tweets")
             all_valid_tweets.extend(valid_tweets)
 
-        query_exists = False
-        for indexed_tweet in self.validator.indexed_tweets:
-            if indexed_tweet["query"] == query:
-                existing_tweet_ids = {
-                    tweet["Tweet"]["ID"] for tweet in indexed_tweet["tweets"]
-                }
-                unique_valid_tweets = [
-                    tweet
-                    for tweet in all_valid_tweets
-                    if tweet["Tweet"]["ID"] not in existing_tweet_ids
-                ]
-                indexed_tweet["tweets"].extend(unique_valid_tweets)
-                query_exists = True
-                break
+            # note, score only unique tweets per miner (uid)
+            uid_int = int(uid)
 
-        if not query_exists:
-            payload = {
-                "query": query,
-                "tweets": [
-                    tweet
-                    for tweet in {
-                        tweet["Tweet"]["ID"]: tweet
-                        for tweet in all_valid_tweets  # note, only unique tweets
-                    }.values()
-                ],
+            if not self.validator.tweets_by_uid.get(uid_int):
+                self.validator.tweets_by_uid[uid_int] = {
+                    tweet["Tweet"]["ID"] for tweet in valid_tweets
+                }
+                self.validator.scorer.add_volume(uid_int, len(valid_tweets))
+                bt.logging.success(
+                    f"Miner {uid_int} produced {len(valid_tweets)} valid new tweets"
+                )
+            else:
+                existing_tweet_ids = self.validator.tweets_by_uid[uid_int]
+                new_tweet_ids = {tweet["Tweet"]["ID"] for tweet in valid_tweets}
+                updates = new_tweet_ids - existing_tweet_ids
+                self.validator.tweets_by_uid[uid_int].update(new_tweet_ids)
+                self.validator.scorer.add_volume(uid_int, len(updates))
+                bt.logging.success(
+                    f"Miner {uid_int} produced {len(updates)} new tweets, with a total of {len(self.validator.tweets_by_uid[uid_int])}."
+                )
+
+        # note, indexing tweets on the validator cpu
+        # TODO, we need to move this to a central database / location
+        # note, most validators have their API off so this data cannot currently be accessed by default
+        if random_keyword in self.validator.tweets_by_query:
+            existing_tweet_ids = {
+                tweet["Tweet"]["ID"]
+                for tweet in self.validator.tweets_by_query[random_keyword]
             }
-            self.validator.indexed_tweets.append(payload)
+            unique_valid_tweets = [
+                tweet
+                for tweet in all_valid_tweets
+                if tweet["Tweet"]["ID"] not in existing_tweet_ids
+            ]
+            self.validator.tweets_by_query[random_keyword].extend(unique_valid_tweets)
+        else:
+            self.validator.tweets_by_query[random_keyword] = [
+                tweet
+                for tweet in {
+                    tweet["Tweet"]["ID"]: tweet
+                    for tweet in all_valid_tweets  # note, only unique tweets
+                }.values()
+            ]
 
         # note, set the last volume block to the current block
         self.validator.last_volume_block = self.validator.subtensor.block

--- a/masa/validator/scorer.py
+++ b/masa/validator/scorer.py
@@ -21,6 +21,8 @@ import torch
 import scipy.stats as stats
 from fastapi.responses import JSONResponse
 
+VOLUME_SCORING_WINDOW = 6
+
 
 class Scorer:
     def __init__(self, validator):
@@ -34,6 +36,7 @@ class Scorer:
 
         if not self.validator.volumes or self.validator.volumes[-1]["tempo"] != tempo:
             self.validator.volumes.append({"tempo": tempo, "miners": {}})
+            self.validator.volumes = self.validator.volumes[-VOLUME_SCORING_WINDOW:]
 
         if miner_uid not in self.validator.volumes[-1]["miners"]:
             self.validator.volumes[-1]["miners"][miner_uid] = 0
@@ -43,7 +46,7 @@ class Scorer:
         volumes = self.validator.volumes
 
         miner_volumes = {}
-        for volume in volumes[-6:]:  # note, take the last 6 tempos
+        for volume in volumes[-VOLUME_SCORING_WINDOW:]:
             for miner_uid, vol in volume["miners"].items():
                 if miner_uid not in miner_volumes:
                     miner_volumes[miner_uid] = 0

--- a/masa/validator/scorer.py
+++ b/masa/validator/scorer.py
@@ -21,8 +21,6 @@ import torch
 import scipy.stats as stats
 from fastapi.responses import JSONResponse
 
-VOLUME_SCORING_WINDOW = 6
-
 
 class Scorer:
     def __init__(self, validator):
@@ -36,7 +34,9 @@ class Scorer:
 
         if not self.validator.volumes or self.validator.volumes[-1]["tempo"] != tempo:
             self.validator.volumes.append({"tempo": tempo, "miners": {}})
-            self.validator.volumes = self.validator.volumes[-VOLUME_SCORING_WINDOW:]
+            self.validator.volumes = self.validator.volumes[
+                -self.validator.volume_window :
+            ]
 
         if miner_uid not in self.validator.volumes[-1]["miners"]:
             self.validator.volumes[-1]["miners"][miner_uid] = 0
@@ -46,7 +46,7 @@ class Scorer:
         volumes = self.validator.volumes
 
         miner_volumes = {}
-        for volume in volumes[-VOLUME_SCORING_WINDOW:]:
+        for volume in volumes[-self.validator.volume_window :]:
             for miner_uid, vol in volume["miners"].items():
                 if miner_uid not in miner_volumes:
                     miner_volumes[miner_uid] = 0


### PR DESCRIPTION
**Description**

This PR fixes #300 and reduces randomness in how validators select miners for scoring, and the keyword that they use.

Validators now keep a set of "uncalled uids", specifically used for volume scoring.  When this set of uncalled uids reaches 0, we establish a new query (from the list of trending queries), and reset the set to version-checked uids from the metagraph.

This new logic ensures that per validator, miners are scored fairly, by exhausting the miners in the metagraph before re-calling any UID, and by keeping the query / keyword consistent through each iteration of the list.

Other aspects of the code were cleaned up, like keeping volume tracking to only the last 6 tempos, and removing miner versioning from state, as we do not need it to persist.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Masa! 
Contributing Conventions
-------------------------
The draft above helps to give a quick overview of your PR.
Remember to remove this comment and to at least:
1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
