### PR TITLE
feat: tweets by UID (miner)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-# SUBTENSOR_ENVIRONMENT = $(TESTNET)
-SUBTENSOR_ENVIRONMENT = $(MAINNET)
+SUBTENSOR_ENVIRONMENT = $(TESTNET)
+# SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-# NETUID = 165 # testnet
-NETUID = 42 # mainnet
+NETUID = 165 # testnet
+# NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,10 +80,10 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit
+	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit --twitter.max_tweets_per_request 10
 
 run-validator:
-	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off
+	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off --enable_validator_api
 
 ## Docker commands
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ MAINNET = network finney
 ########################################################################
 
 # SUBTENSOR_ENVIRONMENT = $(DEV_NET)
-SUBTENSOR_ENVIRONMENT = $(TESTNET)
-# SUBTENSOR_ENVIRONMENT = $(MAINNET)
+# SUBTENSOR_ENVIRONMENT = $(TESTNET)
+SUBTENSOR_ENVIRONMENT = $(MAINNET)
 
 # NETUID = 1 # devnet
-NETUID = 165 # testnet
-# NETUID = 42 # mainnet
+# NETUID = 165 # testnet
+NETUID = 42 # mainnet
 
 ########################################################################
 #####                       USEFUL COMMANDS                        #####
@@ -80,10 +80,10 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit --twitter.max_tweets_per_request 10
+	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit --twitter.max_tweets_per_request 200
 
 run-validator:
-	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off --enable_validator_api
+	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off
 
 ## Docker commands
 docker-build:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ set-weights:
 
 ## Run miner and validator
 run-miner:
-	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit --twitter.max_tweets_per_request 200
+	python neurons/miner.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name miner --wallet.hotkey default --axon.port 8091 --neuron.debug --logging.debug --blacklist.force_validator_permit
 
 run-validator:
 	python neurons/validator.py --netuid $(NETUID) --subtensor.$(SUBTENSOR_ENVIRONMENT) --wallet.name validator --wallet.hotkey default --axon.port 8092 --neuron.debug --logging.debug --neuron.axon_off

--- a/masa/api/server.py
+++ b/masa/api/server.py
@@ -219,7 +219,10 @@ class API:
     async def show_tweets_by_uid(self):
         tweets = self.validator.tweets_by_uid
         if len(tweets) > 0:
-            return JSONResponse(content=tweets)
+            serializable_tweets = {
+                uid: list(tweet_set) for uid, tweet_set in tweets.items()
+            }
+            return JSONResponse(content=serializable_tweets)
         return JSONResponse(content=[])
 
     def delete_miner_volumes(self):

--- a/masa/api/server.py
+++ b/masa/api/server.py
@@ -49,52 +49,6 @@ class API:
             tags=["twitter"],
         )
 
-        # self.app.add_api_route(
-        #     "/data/discord/profile",
-        #     self.validator.forwarder.get_discord_profile,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord profile for the given user ID",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/channels/{channel_id}/messages",
-        #     self.validator.forwarder.get_discord_channel_messages,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord channel messages for the given channel ID",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/guilds/{guild_id}/channels",
-        #     self.validator.forwarder.get_discord_guild_channels,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord channels for the given guild ID",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/user/guilds",
-        #     self.validator.forwarder.get_discord_user_guilds,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get the Discord guilds for the user",
-        #     tags=["discord"],
-        # )
-
-        # self.app.add_api_route(
-        #     "/data/discord/guilds/all",
-        #     self.validator.forwarder.get_discord_all_guilds,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Get all guilds that all the Discord workers are apart of",
-        #     tags=["discord"],
-        # )
-
-        # note, healthcheck for the validator
         self.app.add_api_route(
             "/healthcheck",
             self.healthcheck,
@@ -131,27 +85,6 @@ class API:
             tags=["scoring"],
         )
 
-        # note, only for testing / wiping state
-        # self.app.add_api_route(
-        #     "/volumes",
-        #     self.delete_miner_volumes,
-        #     methods=["DELETE"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Delete volumes state",
-        #     tags=["scoring"],
-        # )
-
-        # note, only for testing, this also runs on a dedciated thread
-        # self.app.add_api_route(
-        #     "/score",
-        #     self.validator.scorer.score_miner_volumes,
-        #     methods=["GET"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Score miner volumes",
-        #     tags=["scoring"],
-        # )
-
-        # note, show the scores the validator has computed
         self.app.add_api_route(
             "/scores",
             self.show_scores,
@@ -178,16 +111,6 @@ class API:
             response_description="Get indexed tweets by UID",
             tags=["data"],
         )
-
-        # note, only for testing / wiping state
-        # self.app.add_api_route(
-        #     "/tweets",
-        #     self.delete_tweets_by_query,
-        #     methods=["DELETE"],
-        #     dependencies=[Depends(self.get_self)],
-        #     response_description="Delete indexed tweets",
-        #     tags=["data"],
-        # )
 
         self.start_server()
 
@@ -224,24 +147,6 @@ class API:
             }
             return JSONResponse(content=serializable_tweets)
         return JSONResponse(content=[])
-
-    def delete_miner_volumes(self):
-        self.validator.volumes = []
-        return JSONResponse(
-            content={
-                "message": "Volumes state deleted",
-                "volumes": self.validator.volumes,
-            }
-        )
-
-    def delete_tweets_by_query(self):
-        self.validator.tweets_by_query = []
-        return JSONResponse(
-            content={
-                "message": "Index tweets deleted",
-                "volumes": self.validator.tweets_by_query,
-            }
-        )
 
     def get_axons(self):
         return self.validator.metagraph.axons

--- a/masa/api/server.py
+++ b/masa/api/server.py
@@ -162,11 +162,20 @@ class API:
         )
 
         self.app.add_api_route(
-            "/tweets",
+            "/tweets_by_query",
             self.show_tweets_by_query,
             methods=["GET"],
             dependencies=[Depends(self.get_self)],
-            response_description="Get indexed tweets",
+            response_description="Get indexed tweets by query",
+            tags=["data"],
+        )
+
+        self.app.add_api_route(
+            "/tweets_by_uid",
+            self.show_tweets_by_uid,
+            methods=["GET"],
+            dependencies=[Depends(self.get_self)],
+            response_description="Get indexed tweets by UID",
             tags=["data"],
         )
 
@@ -203,6 +212,12 @@ class API:
 
     async def show_tweets_by_query(self):
         tweets = self.validator.tweets_by_query
+        if len(tweets) > 0:
+            return JSONResponse(content=tweets)
+        return JSONResponse(content=[])
+
+    async def show_tweets_by_query(self):
+        tweets = self.validator.tweets_by_uid
         if len(tweets) > 0:
             return JSONResponse(content=tweets)
         return JSONResponse(content=[])

--- a/masa/api/server.py
+++ b/masa/api/server.py
@@ -216,7 +216,7 @@ class API:
             return JSONResponse(content=tweets)
         return JSONResponse(content=[])
 
-    async def show_tweets_by_query(self):
+    async def show_tweets_by_uid(self):
         tweets = self.validator.tweets_by_uid
         if len(tweets) > 0:
             return JSONResponse(content=tweets)

--- a/masa/api/server.py
+++ b/masa/api/server.py
@@ -163,7 +163,7 @@ class API:
 
         self.app.add_api_route(
             "/tweets",
-            self.show_indexed_tweets,
+            self.show_tweets_by_query,
             methods=["GET"],
             dependencies=[Depends(self.get_self)],
             response_description="Get indexed tweets",
@@ -173,7 +173,7 @@ class API:
         # note, only for testing / wiping state
         # self.app.add_api_route(
         #     "/tweets",
-        #     self.delete_indexed_tweets,
+        #     self.delete_tweets_by_query,
         #     methods=["DELETE"],
         #     dependencies=[Depends(self.get_self)],
         #     response_description="Delete indexed tweets",
@@ -201,8 +201,8 @@ class API:
             return JSONResponse(content=scores.tolist())
         return JSONResponse(content=[])
 
-    async def show_indexed_tweets(self):
-        tweets = self.validator.indexed_tweets
+    async def show_tweets_by_query(self):
+        tweets = self.validator.tweets_by_query
         if len(tweets) > 0:
             return JSONResponse(content=tweets)
         return JSONResponse(content=[])
@@ -216,12 +216,12 @@ class API:
             }
         )
 
-    def delete_indexed_tweets(self):
-        self.validator.indexed_tweets = []
+    def delete_tweets_by_query(self):
+        self.validator.tweets_by_query = []
         return JSONResponse(
             content={
                 "message": "Index tweets deleted",
-                "volumes": self.validator.indexed_tweets,
+                "volumes": self.validator.tweets_by_query,
             }
         )
 

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -389,6 +389,9 @@ class BaseValidatorNeuron(BaseNeuron):
                     if uid in volume["miners"]:
                         volume["miners"][uid] = 0
 
+                # Replace unique tweets by uid
+                self.tweets_by_uid[uid] = set()
+
         # Check to see if the metagraph has changed size.
         # If so, we need to add new hotkeys and moving averages.
         if len(self.hotkeys) < len(self.metagraph.hotkeys):

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -459,6 +459,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 "scores": self.scores,
                 "hotkeys": self.hotkeys,
                 "volumes": self.volumes,
+                "tweets_by_uid": self.tweets_by_uid,
                 # TODO, note, this grows indefinitely, we need a central store for this
                 "indexed_tweets": self.indexed_tweets,
             },
@@ -477,12 +478,14 @@ class BaseValidatorNeuron(BaseNeuron):
             self.scores = dict(state).get("scores", [])
             self.hotkeys = dict(state).get("hotkeys", [])
             self.volumes = dict(state).get("volumes", [])
+            self.tweets_by_uid = dict(state).get("tweets_by_uid", {})
             self.indexed_tweets = dict(state).get("indexed_tweets", [])
         else:
             self.step = 0
             self.scores = torch.zeros(self.metagraph.n)
             self.hotkeys = []
             self.volumes = []
+            self.tweets_by_uid = {}
             self.indexed_tweets = []
             bt.logging.warning(
                 f"State file not found at {state_path}. Skipping state load."

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -108,7 +108,6 @@ class BaseValidatorNeuron(BaseNeuron):
         self.last_scoring_block = 0
 
         self.versions = []  # note, for storing uid versions
-        self.keyword = ""  # note, current keyword
         self.keywords = []  # note, for volume scoring queries
         self.uncalled_uids = set()  # note, for volume scoring queries
         self.volume_window = 6  # note, score volumes from last 6 tempos
@@ -463,8 +462,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 "hotkeys": self.hotkeys,
                 "volumes": self.volumes,
                 "tweets_by_uid": self.tweets_by_uid,
-                # TODO, note, this grows indefinitely, we need a central store for this
-                "indexed_tweets": self.indexed_tweets,
+                "tweets_by_query": self.tweets_by_query,
             },
             self.config.neuron.full_path + "/state.pt",
         )
@@ -482,14 +480,14 @@ class BaseValidatorNeuron(BaseNeuron):
             self.hotkeys = dict(state).get("hotkeys", [])
             self.volumes = dict(state).get("volumes", [])
             self.tweets_by_uid = dict(state).get("tweets_by_uid", {})
-            self.indexed_tweets = dict(state).get("indexed_tweets", [])
+            self.tweets_by_query = dict(state).get("tweets_by_query", {})
         else:
             self.step = 0
             self.scores = torch.zeros(self.metagraph.n)
             self.hotkeys = []
             self.volumes = []
             self.tweets_by_uid = {}
-            self.indexed_tweets = []
+            self.tweets_by_query = {}
             bt.logging.warning(
                 f"State file not found at {state_path}. Skipping state load."
             )

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -179,13 +179,11 @@ class Forwarder:
             if not all_responses:
                 continue
 
-            unique_tweets_response = []
-            existing_ids = set()
-            for resp in all_responses:
-                tweet_id = resp.get("Tweet", {}).get("ID")
-                if tweet_id and tweet_id not in existing_ids:
-                    unique_tweets_response.append(resp)
-                    existing_ids.add(tweet_id)
+            unique_tweets_response = {
+                resp["Tweet"]["ID"]: resp
+                for resp in all_responses
+                if "Tweet" in resp and "ID" in resp["Tweet"]
+            }.values()
 
             if unique_tweets_response is not None:
                 # note, first spot check this payload, ensuring a random tweet is valid

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -268,7 +268,6 @@ class Forwarder:
             uid_int = int(uid)
 
             if not self.validator.tweets_by_uid.get(uid_int):
-                # TODO we need to wipe this from sync metagraph when hotkey changes
                 self.validator.tweets_by_uid[uid_int] = {
                     tweet["Tweet"]["ID"] for tweet in valid_tweets
                 }

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -259,7 +259,7 @@ class Forwarder:
                                     tweet_embedding,
                                 )
                             )
-                            if similarity >= 60:  # pretty strict
+                            if similarity >= 70:  # pretty strict
                                 valid_tweets.append(tweet)
                 else:
                     bt.logging.warning(f"Miner {uid} failed the spot check!")

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -286,7 +286,9 @@ class Forwarder:
                     f"Miner {uid_int} produced {len(updates)} new tweets, with a total of {len(self.validator.tweets_by_uid[uid_int])}."
                 )
 
-        # tweet indexing
+        # note, indexing tweets on the validator cpu
+        # TODO, we need to move this to a central database / location
+        # note, most validators have their API off so this data cannot currently be accessed by default
         if random_keyword in self.validator.tweets_by_query:
             existing_tweet_ids = {
                 tweet["Tweet"]["ID"]


### PR DESCRIPTION
**Description**

This PR fixes #299 and stores tweets by uid, to ensure that each miner is only being scored on unique tweets each turn.  We wipe the state when a UID is ever deregistered (determined by resync_metagraph()).

There were also updates to indexing tweets, so we just store by query and unique tweet.  This makes it easier for us to index the data in a future, central service.  Typing this again to pass CI!

This PR fixes #299 and stores tweets by uid, to ensure that each miner is only being scored on unique tweets each turn.  We wipe the state when a UID is ever deregistered (determined by resync_metagraph()).

There were also updates to indexing tweets, so we just store by query and unique tweet.  This makes it easier for us to index the data in a future, central service.  Typing this again to pass CI!

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Masa! 
Contributing Conventions
-------------------------
The draft above helps to give a quick overview of your PR.
Remember to remove this comment and to at least:
1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR. 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
