### PR TITLE
fix(scoring): padded zeros

### DIFF
--- a/masa/__init__.py
+++ b/masa/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the code version for miners / validators.  This must match weights_version on the subnet!  If not, validators won't be able to set weights, and miners will get a warning.
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (100 * int(version_split[0]))

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -213,6 +213,7 @@ class Forwarder:
             if not all_responses:
                 continue
 
+            # TODO lets remove all padded 0's from the response IDs
             unique_tweets_response = list(
                 {
                     resp["Tweet"]["ID"]: resp

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -216,9 +216,13 @@ class Forwarder:
             # also remove all padded 0's from the response IDs
             unique_tweets_response = list(
                 {
-                    resp["Tweet"]["ID"].lstrip(
-                        "0"
-                    ): resp  # Strip leading zeros from IDs
+                    resp["Tweet"]["ID"].lstrip("0"): {
+                        **resp,
+                        "Tweet": {
+                            **resp["Tweet"],
+                            "ID": resp["Tweet"]["ID"].lstrip("0"),
+                        },
+                    }
                     for resp in all_responses
                     if "Tweet" in resp and "ID" in resp["Tweet"]
                 }.values()

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -213,10 +213,12 @@ class Forwarder:
             if not all_responses:
                 continue
 
-            # TODO lets remove all padded 0's from the response IDs
+            # also remove all padded 0's from the response IDs
             unique_tweets_response = list(
                 {
-                    resp["Tweet"]["ID"]: resp
+                    resp["Tweet"]["ID"].lstrip(
+                        "0"
+                    ): resp  # Strip leading zeros from IDs
                     for resp in all_responses
                     if "Tweet" in resp and "ID" in resp["Tweet"]
                 }.values()


### PR DESCRIPTION
**Description**

Malicious miners were padding their tweet id's with zeros, passing our validation logic and scoring uniquely in our algorithm.  This PR fixes said issue in the following ways:

#### 1. Version Update
- **File:** `masa/__init__.py`
- **Change:** The version of the code has been updated from `1.2.0` to `1.3.0`.
- **Impact:** This version bump indicates a new release with potentially new features, improvements, or bug fixes. It is crucial for ensuring compatibility with the subnet's `weights_version`.

#### 2. Response ID Handling
- **File:** `masa/validator/forwarder.py`
- **Class:** `Forwarder`
- **Change:** 
  - The logic for handling tweet response IDs has been updated to remove leading zeros.
  - The `unique_tweets_response` now uses IDs stripped of leading zeros as dictionary keys.
  - Additionally, the `Tweet` object within each response is updated to reflect the stripped ID.
  
- **Code Update:**
  ```python
  unique_tweets_response = list(
      {
          resp["Tweet"]["ID"].lstrip("0"): {
              **resp,
              "Tweet": {
                  **resp["Tweet"],
                  "ID": resp["Tweet"]["ID"].lstrip("0"),
              },
          }
          for resp in all_responses
          if "Tweet" in resp and "ID" in resp["Tweet"]
      }.values()
  )
  ```

- **Impact:**
  - **Data Consistency:** Ensures that all tweet IDs are consistent by removing leading zeros, which can prevent potential mismatches or errors in ID handling.
  - **Backward Compatibility:** The change is internal to the ID processing and should not affect external systems unless they rely on IDs with leading zeros.
  - **Bug Prevention:** This update can prevent issues related to ID comparison or storage where leading zeros might cause discrepancies.

#### Additional Notes:
- **Testing:** The changes have been tested on SN42 mainnet validator.
