### PR TITLE
fix: do not save certain state

### DIFF
--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -284,7 +284,10 @@ class BaseValidatorNeuron(BaseNeuron):
                 "Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions."
             )
 
-        # Check if all scores are the same
+        # Check if scores are empty or all scores are the same
+        if self.scores.numel() == 0:
+            bt.logging.warning("Scores are empty. Skipping set_weights.")
+            return
         if torch.all(self.scores == self.scores[0]):
             bt.logging.warning("All scores are the same. Skipping set_weights.")
             return
@@ -480,7 +483,7 @@ class BaseValidatorNeuron(BaseNeuron):
         if os.path.isfile(state_path):
             state = torch.load(state_path, map_location=torch.device("cpu"))
             self.step = dict(state).get("step", 0)
-            self.scores = dict(state).get("scores", [])
+            self.scores = dict(state).get("scores", torch.zeros(self.metagraph.n))
             self.hotkeys = dict(state).get("hotkeys", [])
             self.volumes = dict(state).get("volumes", [])
             self.tweets_by_uid = dict(state).get("tweets_by_uid", {})

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -458,10 +458,10 @@ class BaseValidatorNeuron(BaseNeuron):
         torch.save(
             {
                 "step": self.step,
-                "scores": self.scores,
+                # "scores": self.scores,
                 "hotkeys": self.hotkeys,
                 "volumes": self.volumes,
-                "tweets_by_uid": self.tweets_by_uid,
+                # "tweets_by_uid": self.tweets_by_uid,
             },
             self.config.neuron.full_path + "/state.pt",
         )

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -284,6 +284,11 @@ class BaseValidatorNeuron(BaseNeuron):
                 "Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions."
             )
 
+        # Check if all scores are the same
+        if torch.all(self.scores == self.scores[0]):
+            bt.logging.warning("All scores are the same. Skipping set_weights.")
+            return
+
         # Calculate the average reward for each uid across non-zero values.
         raw_weights = torch.nn.functional.normalize(self.scores, p=1, dim=0)
 

--- a/masa/base/validator.py
+++ b/masa/base/validator.py
@@ -457,10 +457,10 @@ class BaseValidatorNeuron(BaseNeuron):
         # Save the state of the validator to file.
         torch.save(
             {
-                "step": self.step,
+                # "step": self.step,
                 # "scores": self.scores,
-                "hotkeys": self.hotkeys,
-                "volumes": self.volumes,
+                # "hotkeys": self.hotkeys,
+                # "volumes": self.volumes,
                 # "tweets_by_uid": self.tweets_by_uid,
             },
             self.config.neuron.full_path + "/state.pt",


### PR DESCRIPTION
**Description**

This PR removes state persistence for the validator node, as it was causing stability issues. The validator already maintains state in memory and rarely needs to restart, making persistent storage unnecessary and potentially problematic.

**Changes**
- Removed state persistence functionality
- Simplified validator state management to rely on in-memory storage
- Improves validator stability by eliminating state-related issues

**Related Issues**
- Addresses validator stability issues

**Testing**
- [ ] Tested validator operation without state persistence
- [ ] Verified validator stability in continuous operation
- [ ] Confirmed no data loss during normal operation

**Notes for Reviewers**
The removal of state persistence is intentional as discussed, since:
1. The validator maintains state in memory
2. Restarts are infrequent
3. Previous state persistence was causing stability issues

**Signed commits**
- [x] Yes, I signed my commits.