### PR TITLE
fix: Validation Logic and Clean Up Logging

### DIFF
--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -417,10 +417,6 @@ class Forwarder:
                         all_tweets_valid = False
                         break  # Break inner loop
 
-                bt.logging.info(
-                    f"✅ {self.format_miner_info(uid)} PASSED - {len(all_responses)} valid tweets"
-                )
-
                 # Check for duplicates - if number of unique IDs doesn't match total tweets, batch has duplicates
                 unique_ids = {tweet["Tweet"]["ID"] for tweet in all_responses}
                 if len(unique_ids) != len(all_responses):
@@ -501,45 +497,47 @@ class Forwarder:
                     f"{'✅' if is_since_date_requested else '❌'} Timestamp ({tweet_timestamp.strftime('%Y-%m-%d %H:%M:%S')} >= {yesterday.strftime('%Y-%m-%d')}): {tweet_url}"
                 )
 
-                # note, score only unique tweets per miner (uid)
-                uid_int = int(uid)
+                # If all tweets passed validation, handle volume scoring and export
+                if all_tweets_valid:
+                    uid_int = int(uid)
 
-                if not self.validator.tweets_by_uid.get(uid_int):
-                    self.validator.tweets_by_uid[uid_int] = {
-                        tweet["Tweet"]["ID"] for tweet in all_responses
-                    }
-                    new_tweet_count = len(all_responses)
-                    self.validator.scorer.add_volume(
-                        uid_int, new_tweet_count, current_block
-                    )
-                    bt.logging.info(
-                        f"First submission from {self.format_miner_info(uid_int)}: {new_tweet_count} new tweets"
-                    )
-                else:
-                    existing_tweet_ids = self.validator.tweets_by_uid[uid_int]
-                    new_tweet_ids = {tweet["Tweet"]["ID"] for tweet in all_responses}
-                    updates = new_tweet_ids - existing_tweet_ids
-                    duplicate_with_history = len(new_tweet_ids) - len(updates)
-
-                    if duplicate_with_history > 0:
+                    # Handle volume scoring
+                    if not self.validator.tweets_by_uid.get(uid_int):
+                        self.validator.tweets_by_uid[uid_int] = {
+                            tweet["Tweet"]["ID"] for tweet in all_responses
+                        }
+                        new_tweet_count = len(all_responses)
+                        self.validator.scorer.add_volume(
+                            uid_int, new_tweet_count, current_block
+                        )
                         bt.logging.info(
-                            f"Found {duplicate_with_history} previously seen tweets from {self.format_miner_info(uid_int)} "
-                            f"(reduced from {len(new_tweet_ids)} to {len(updates)} new tweets)"
+                            f"First submission from {self.format_miner_info(uid_int)}: {new_tweet_count} new tweets"
                         )
                     else:
-                        bt.logging.debug(
-                            f"All {len(new_tweet_ids)} tweets from {self.format_miner_info(uid_int)} are new"
+                        existing_tweet_ids = self.validator.tweets_by_uid[uid_int]
+                        new_tweet_ids = {
+                            tweet["Tweet"]["ID"] for tweet in all_responses
+                        }
+                        updates = new_tweet_ids - existing_tweet_ids
+                        duplicate_with_history = len(new_tweet_ids) - len(updates)
+
+                        if duplicate_with_history > 0:
+                            bt.logging.info(
+                                f"Found {duplicate_with_history} previously seen tweets from {self.format_miner_info(uid_int)} "
+                                f"(reduced from {len(new_tweet_ids)} to {len(updates)} new tweets)"
+                            )
+                        else:
+                            bt.logging.debug(
+                                f"All {len(new_tweet_ids)} tweets from {self.format_miner_info(uid_int)} are new"
+                            )
+
+                        self.validator.tweets_by_uid[uid_int].update(new_tweet_ids)
+                        self.validator.scorer.add_volume(
+                            uid_int, len(updates), current_block
                         )
 
-                    self.validator.tweets_by_uid[uid_int].update(new_tweet_ids)
-                    self.validator.scorer.add_volume(
-                        uid_int, len(updates), current_block
-                    )
-
-                # If all tweets passed validation, export this batch
-                if all_tweets_valid:
                     bt.logging.info(
-                        f"✅ All tweets from {self.format_miner_info(uid)} passed validation, exporting batch"
+                        f"✅ All {len(all_responses)} tweets from {self.format_miner_info(uid)} passed validation, exporting batch"
                     )
 
                     # DETAILED EXPORT LOGGING

--- a/masa/validator/forwarder.py
+++ b/masa/validator/forwarder.py
@@ -632,67 +632,6 @@ class Forwarder:
         """Format a tweet ID into an x.com URL."""
         return f"https://x.com/i/status/{tweet_id}"
 
-    async def process_response(self, uid: int, response: Any) -> None:
-        """Process a single miner's response."""
-        try:
-            # Spot check validation
-            if await self.validate_spot_check(uid, response):
-                bt.logging.debug(f"Miner {uid} passed spot check")
-
-                # Process tweet counts
-                if len(response.get("tweets", [])) > 0:
-                    new_tweets = len(
-                        [t for t in response["tweets"] if self.is_new_tweet(t)]
-                    )
-                    total_tweets = len(response["tweets"])
-
-                    if new_tweets == total_tweets:
-                        bt.logging.debug(
-                            f"Miner {uid} produced {new_tweets} new tweets"
-                        )
-                    else:
-                        bt.logging.debug(
-                            f"Miner {uid} produced {new_tweets} new tweets (total: {total_tweets})"
-                        )
-
-                    # Log sample tweet URL at debug level
-                    if response["tweets"]:
-                        sample_tweet = response["tweets"][0]
-                        bt.logging.debug(
-                            f"Sample tweet from miner {uid}: {self.format_tweet_url(sample_tweet['id'])}"
-                        )
-            else:
-                bt.logging.debug(f"Miner {uid} failed spot check")
-
-        except Exception as e:
-            bt.logging.error(f"Error processing response from miner {uid}: {e}")
-
-    async def validate_spot_check(self, uid: int, response: Any) -> bool:
-        """Validate a random tweet from the response."""
-        try:
-            if not response or not response.get("tweets"):
-                return False
-
-            random_tweet = random.choice(response["tweets"])
-            tweet_id = random_tweet.get("id")
-
-            is_valid = await self.validate_tweet(random_tweet)
-
-            if is_valid:
-                bt.logging.info(
-                    f"Tweet validation passed: {self.format_tweet_url(tweet_id)}"
-                )
-            else:
-                bt.logging.info(
-                    f"Tweet validation failed: {self.format_tweet_url(tweet_id)}"
-                )
-
-            return is_valid
-
-        except Exception as e:
-            bt.logging.error(f"Error in spot check for miner {uid}: {e}")
-            return False
-
     # Helper function to format miner info
     def format_miner_info(self, uid: int) -> str:
         """Format miner info with TaoStats link using hotkey."""


### PR DESCRIPTION
# Fix Validation Logic and Clean Up Logging

## Problem
The validator was showing success messages and adding volume scores prematurely, before all validation checks were complete. This could lead to:
1. Confusing logs showing both PASS and FAIL for the same batch
2. Potential incorrect volume scoring for invalid tweets
3. Misleading validation status reporting

## Changes Made

### 1. Fixed Validation Sequence
- Moved success logging to only appear after ALL validation checks have passed
- Previously we were showing "PASSED - X valid tweets" before completing validation
- Now success messages only appear if all validation steps pass:
  - Basic tweet structure validation
  - Tweet ID validation
  - Duplicate checks within batch
  - Query match validation
  - Timestamp validation
  - Historical duplicate checking

### 2. Fixed Volume Scoring
- Moved ALL volume-related logic inside the `all_tweets_valid` block
- Volume is now only added after complete validation
- Prevents miners from getting volume credit for invalid tweets or failed batches
- Volume scoring now properly considers:
  - First-time submissions
  - Historical duplicates
  - Only valid tweets that pass all checks

### 3. Code Cleanup
- Removed unused legacy validation methods:
  - Removed `validate_spot_check`
  - Removed `process_response`
- These methods were superseded by the more comprehensive validation in `get_miners_volumes`

## Testing
The changes ensure:
- No premature success messages
- No volume credit for invalid tweets
- Clearer logging sequence
- More accurate validation reporting

## Impact
These changes improve:
1. Accuracy of validation reporting
2. Fairness of volume scoring
3. Code maintainability
4. Log clarity and usefulness

## Backwards Compatibility
- No breaking changes
- Only affects logging sequence and internal validation logic
- No changes to API or data structures 