### PR TITLE
fix: set version 1.5.3 in pyproject.yaml

### DIFF
--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -123,10 +123,12 @@ class BaseNeuron(ABC):
 
         if self.spec_version < weights_version:
             bt.logging.warning(
-                f"🟡 Code is outdated based on subnet requirements!  Required: {weights_version}, Current: {self.spec_version}.  Please update your code to the latest release!"
+                f"🟡 Code is outdated based on subnet requirements! Required: {weights_version}, Current: {self.spec_version} (v{__version__}). Please update your code to the latest release!"
             )
         else:
-            bt.logging.success("🟢 Code is up to date based on subnet requirements!")
+            bt.logging.success(
+                f"🟢 Code is up to date! Current: {self.spec_version} (v{__version__}), Required: {weights_version}"
+            )
 
         # Each miner gets a unique identity (UID) in the network for differentiation.
         self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["masa"]
 
 [project]
 name = "masa"
-version = "1.5.0"
+version = "1.5.3"
 description = "bittensor subnet for masa protocol"
 authors = [
     { name = "masa.ai", email = "hello@masa.ai" }


### PR DESCRIPTION
# Version Bump to 1.5.3 and Improved Version Logging

## Description

This PR addresses a version mismatch between our git tags and package version:
- Git tag was at v1.5.2
- But pyproject.yaml still specified 1.5.0
- This caused running validators to report spec_version 150 instead of 152

Additionally, this PR improves version logging to make it clearer what version is running:

🟢 Code is up to date! Current: 153 (v1.5.3), Required: 150

## Why This is Important

1. We will soon update subnet hyperparameters to require version 1.5.2 (spec_version 152)
2. Without this fix, validators would continue reporting version 1.5.0 (spec_version 150)
3. This would cause all validators to fail setting weights once the requirement changes

## Changes
- Update version in pyproject.yaml to 1.5.3
- Improve version logging to show both current and required versions
- Ensure consistent version reporting across all components

## Notes for Reviewers
This is a critical update that must be released before updating subnet hyperparameters.