### PR TITLE
fix: incorrect log line, single source of truth for version number (pyproject.toml)

### DIFF
--- a/masa/__init__.py
+++ b/masa/__init__.py
@@ -17,7 +17,9 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the code version for miners / validators.  This must match weights_version on the subnet!  If not, validators won't be able to set weights, and miners will get a warning.
-__version__ = "1.5.0"
+from importlib.metadata import version
+
+__version__ = version("masa")
 version_split = __version__.split(".")
 __spec_version__ = (
     (100 * int(version_split[0]))

--- a/masa/base/neuron.py
+++ b/masa/base/neuron.py
@@ -123,11 +123,11 @@ class BaseNeuron(ABC):
 
         if self.spec_version < weights_version:
             bt.logging.warning(
-                f"🟡 Code is outdated based on subnet requirements! Required: {weights_version}, Current: {self.spec_version} (v{__version__}). Please update your code to the latest release!"
+                f"🟡 Code is outdated! Current: {self.spec_version}, Required: {weights_version}. Please update your code to the latest release!"
             )
         else:
             bt.logging.success(
-                f"🟢 Code is up to date! Current: {self.spec_version} (v{__version__}), Required: {weights_version}"
+                f"🟢 Code is up to date! Current: {self.spec_version}, Required: {weights_version}"
             )
 
         # Each miner gets a unique identity (UID) in the network for differentiation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["masa"]
 
 [project]
 name = "masa"
-version = "1.5.3"
+version = "1.5.4"
 description = "bittensor subnet for masa protocol"
 authors = [
     { name = "masa.ai", email = "hello@masa.ai" }


### PR DESCRIPTION
# Version Bump to 1.5.4, version reference to one single source of truth, and fix Version Logging

## Description

v1.5.3 had a small issue with logging the version incorrectly, but also had a larger issue with the version reference not being a single source of truth.

previously, to release a new version, one would need to update the version in the pyproject.yaml file, the __init__.py file, and the release notes.

Now, to release a new version, one only needs to update the version in the pyproject.yaml file.

This version bumps up to 1.5.4, and will correctly log the current and required versions at init.

```
🟢 Code is up to date! Current: 154 (v1.5.4), Required: 154
```

or, if not up to date:

🟡 Code is outdated! Current: 153, Required: 154. Please update your code to the latest release!

## Changes
- Update version in pyproject.yaml to 1.5.4
- Uses a single source of truth for the version in __init__.py (only set hardcoded version in pyproject.yaml)
- Improve version logging to show both current and required versions
- Ensure consistent version reporting across all components

## Notes for Reviewers
This is a critical update that must be released before updating subnet hyperparameters.